### PR TITLE
Faster Testing/Debugging For Integrating New Models & Tasks

### DIFF
--- a/src/MEDS_DEV/models/__init__.py
+++ b/src/MEDS_DEV/models/__init__.py
@@ -1,3 +1,4 @@
+import os
 from importlib.resources import files
 
 from omegaconf import OmegaConf
@@ -13,5 +14,9 @@ for path in model_files.rglob("*/model.yaml"):
     requirements_path = path.parent / "requirements.txt"
     MODELS[model_name]["requirements"] = requirements_path if requirements_path.exists() else None
     MODELS[model_name]["model_dir"] = path.parent
+
+if os.environ.get("MEDS_DEV_MODEL_NAMES", None) is not None:
+    valid_models = set(os.environ["MEDS_DEV_MODEL_NAMES"].split(","))
+    MODELS = {model: MODELS[model] for model in MODELS if model in valid_models}
 
 __all__ = ["MODELS", "CFG_YAML"]

--- a/src/MEDS_DEV/tasks/__init__.py
+++ b/src/MEDS_DEV/tasks/__init__.py
@@ -1,3 +1,4 @@
+import os
 from importlib.resources import files
 
 from omegaconf import OmegaConf
@@ -14,5 +15,9 @@ for path in task_files.glob("**/*.yaml"):
         "criteria_fp": path,
         "metadata": metadata,
     }
+
+if os.environ.get("MEDS_DEV_TASK_NAMES", None) is not None:
+    valid_tasks = set(os.environ["MEDS_DEV_TASK_NAMES"].split(","))
+    TASKS = {task: TASKS[task] for task in TASKS if task in valid_tasks}
 
 __all__ = ["TASKS", "CFG_YAML", "ACES_CFG_YAML"]

--- a/src/MEDS_DEV/utils.py
+++ b/src/MEDS_DEV/utils.py
@@ -22,6 +22,8 @@ def get_venv_bin_path(venv_path: str | Path) -> Path:
 @contextlib.contextmanager
 def tempdir_ctx(cfg: DictConfig) -> Path:
     temp_dir = cfg.get("temp_dir", None)
+    if temp_dir is None and os.environ.get("MEDS_DEV_USE_TMP_DIR", None) is not None:
+        temp_dir = os.environ["MEDS_DEV_USE_TMP_DIR"]
     if temp_dir is None:
         with tempfile.TemporaryDirectory() as temp_dir:
             yield Path(temp_dir)

--- a/src/MEDS_DEV/utils.py
+++ b/src/MEDS_DEV/utils.py
@@ -53,7 +53,7 @@ def install_venv(venv_path: Path, requirements: str | Path) -> Path:
 def temp_env(cfg: DictConfig, requirements: str | Path | None) -> tuple[Path, dict]:
     with tempdir_ctx(cfg) as build_temp_dir:
         env = os.environ.copy()
-        if requirements is not None:
+        if requirements is not None and not os.environ.get("MEDS_DEV_USE_CURRENT_ENV", False):
             venv_path = build_temp_dir / ".venv"
             venv_bin_path = install_venv(venv_path, requirements)
             env["PATH"] = f"{str(venv_bin_path)}{os.pathsep}{env['PATH']}"


### PR DESCRIPTION
Addresses: #90 and #81

## Previous Behavior
Previously, running `pytest` would:
- Process all test tasks and models on the MIMIC IV demo dataset
- Install a custom environment for each model run
- Create a full cross-product of all tasks and models

The painpoints are that
1.This could take upwards of 5 minutes which makes debugging much more difficult when you just want to debug a model on a single task.
2. It also is cumbersome because sometimes you need to debug your model code, and you don't want to pip install the model from pypi, you want to use a local version of it in your current python environment and use breakpoints.

## New Features
To address the speed and custom environment paintpoints, there's four bash environment variables to help customize testing:

- `MEDS_DEV_USE_CURRENT_ENV`: Controls environment setup
  - `True`: Use current Python environment
  - `False`: Create fresh venv and install requirements.txt (default)

- `MEDS_DEV_USE_TMP_DIR`: Enables dataset caching
  - When set, uses specified directory for processed datasets
  - Reuses already processed datasets to save time
  - Example: `/home/nassim/tmp/mimic_iv_meds_dev/`

- `MEDS_DEV_TASK_NAMES`: Filters tasks to test
  - Comma-separated list of task names
  - Example: `abnormal_lab/cbc/anemia/first_24h`

- `MEDS_DEV_MODEL_NAMES`: Filters models to test
  - Comma-separated list of model names
  - Example: `meds_tab`

### Example Usage
```bash
MEDS_DEV_USE_CURRENT_ENV=True \
MEDS_DEV_USE_TMP_DIR="/home/nassim/tmp/mimic_iv_meds_dev/" \
MEDS_DEV_TASK_NAMES="abnormal_lab/cbc/anemia/first_24h" \
MEDS_DEV_MODEL_NAMES="meds_tab" \
pytest
```