### PR TITLE
Upgrade meds-tab to 0.2.0 (fixes scipy build failure)

### DIFF
--- a/src/MEDS_DEV/models/meds_tab/tiny/model.yaml
+++ b/src/MEDS_DEV/models/meds_tab/tiny/model.yaml
@@ -39,7 +39,6 @@ commands:
           "input_dir={dataset_dir}/data" "output_dir={output_dir}/meds_tab" \
           "output_model_dir={output_dir}/results" "task_name=null" do_overwrite=False \
           "hydra.sweeper.n_trials=20" "hydra.sweeper.n_jobs=1" \
-          "hydra.sweeper.max_failure_rate=0.5" \
           "input_tabularized_cache_dir={output_dir}/meds_tab/tabularize/" \
           "input_label_cache_dir={labels_dir}" \
           "tabularization.aggs=[code/count,value/sum]" \

--- a/src/MEDS_DEV/models/meds_tab/tiny/requirements.txt
+++ b/src/MEDS_DEV/models/meds_tab/tiny/requirements.txt
@@ -1,2 +1,1 @@
-meds-tab==0.1
-hydra-optuna-sweeper==1.3.0.dev0
+meds-tab==0.2.0


### PR DESCRIPTION
## Summary

- Bump `meds-tab` from 0.1 to 0.2.0 — the new version no longer pins `scipy==1.6.1`, which failed to build on Python 3.11+ (no prebuilt wheels, requires BLAS/LAPACK for source builds)
- Remove the explicit `hydra-optuna-sweeper==1.3.0.dev0` pin — meds-tab 0.2.0 pulls in its own compatible version (1.2.0)
- Remove `hydra.sweeper.max_failure_rate=0.5` from model.yaml — this parameter doesn't exist in `hydra-optuna-sweeper` 1.2.0's `OptunaSweeperConf`

## Test plan

- [x] All `meds_tab/tiny` tests pass locally (67 passed, 7 skipped)
- [ ] CI passes

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)