### PR TITLE
Fix Codecov upload: add --cov-report=xml

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -241,7 +241,7 @@ jobs:
 
       - name: Run full test suite
         run: |
-          uv run pytest -v --doctest-modules --cov=src --junitxml=junit.xml -s -x
+          uv run pytest -v --doctest-modules --cov=src --cov-report=xml --junitxml=junit.xml -s -x
 
       - name: Upload coverage to Codecov
         if: always()


### PR DESCRIPTION
## Summary
- Codecov was failing on main with "Found 0 coverage files to report" because `pytest --cov=src` only generates a `.coverage` binary file, not the XML report Codecov expects
- Added `--cov-report=xml` to the pytest command in the `full-integration` job so `coverage.xml` is generated

## Context
From the [latest main CI run](https://github.com/Medical-Event-Data-Standard/MEDS-DEV/actions/runs/24268307780):
```
warning - coverage.py is not installed or can't be found.
info - Found 0 coverage files to report
Error: No coverage reports found.
```

The `codecov-action@v4.0.1` uploader looks for XML coverage reports (`coverage.xml`) by default. Without `--cov-report=xml`, pytest-cov only writes the binary `.coverage` file.

## Test plan
- [ ] Verify the `full-integration` job generates `coverage.xml` and Codecov upload succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)