### PR TITLE
Fix Codecov upload: add --cov-report=xml

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
       #----------------------------------------------
       - name: Run tests
         run: |
-          uv run pytest -v --cov=src --junitxml=junit.xml -s -x
+          uv run pytest -v --cov=src --cov-report=xml --junitxml=junit.xml -s -x
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4.0.1


### PR DESCRIPTION
## Summary
- Codecov was failing with "Found 0 coverage files to report" because `pytest --cov=src` only generates a `.coverage` binary file
- Added `--cov-report=xml` so `coverage.xml` is generated for Codecov to upload

## Context
From the [latest main CI run](https://github.com/Medical-Event-Data-Standard/MEDS-DEV/actions/runs/24268307780):
```
warning - coverage.py is not installed or can't be found.
info - Found 0 coverage files to report
Error: No coverage reports found.
```

## Test plan
- [ ] Verify Codecov upload succeeds after merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)