### PR TITLE
Upgrade Codecov to v6 and fix coverage report

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -241,19 +241,22 @@ jobs:
 
       - name: Run full test suite
         run: |
-          uv run pytest -v --doctest-modules --cov=src --junitxml=junit.xml -s -x
+          uv run pytest -v --doctest-modules --cov=src --cov-report=xml --junitxml=junit.xml -s -x
 
       - name: Upload coverage to Codecov
         if: always()
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
+          files: ./junit.xml
 
   # ---------------------------------------------------------------------------
   # Job 7: Summary — report what ran (named run_tests_ubuntu for branch ruleset compatibility)


### PR DESCRIPTION
## Summary
- Add `--cov-report=xml` to pytest so `coverage.xml` is generated (fixes "Found 0 coverage files" error)
- Upgrade from `codecov/codecov-action@v4.0.1` to `v6.0.0` (node24 support, avoids June 2026 deprecation)
- Replace deprecated `codecov/test-results-action@v1` with `codecov-action@v6.0.0` using `report_type: test_results`
- Explicitly specify upload files for both coverage and test results

## Pre-commit versions
All pre-commit hook versions were already pinned (repos, additional_dependencies). No changes needed.

## Test plan
- [ ] CI passes on this PR
- [ ] After merging the hotfix PR #277 to main and back-merging to dev, verify Codecov uploads succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)