### PR TITLE
Add MEDS_DEV.web module: collate-entities and aggregate-results CLIs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,48 +2,21 @@
 
 The ``yaml_to_disk`` and ``pretty_print_directory`` packages each ship a pytest plugin that registers
 ``yaml_disk`` / ``print_directory`` / ``PrintConfig`` for use in doctests without explicit imports.
-This file extends that pattern for ``Path``, ``json``, and ``capture_log_to_stdout`` so module-level
-doctests don't have to spend their first line on boilerplate imports / setup.
+This file extends that pattern for ``Path``, ``json``, and pytest's ``caplog`` fixture, so doctests
+that need to assert on log output can use the standard pytest mechanism without leaving the doctest.
 
 Per-module behavioral fixtures still live in ``tests/conftest.py`` — this file only covers the
 doctest namespace.
 """
 
-import contextlib
 import json
-import logging
-import sys
-from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 
 
-@contextlib.contextmanager
-def capture_log_to_stdout(logger_name: str, level: int = logging.INFO) -> Iterator[None]:
-    """Route a logger to ``sys.stdout`` so its messages are visible in doctest output.
-
-    Doctests don't have pytest's ``caplog`` fixture; assertions on log output have to round-trip
-    through stdout. This context manager attaches a temporary handler at the given level, then
-    detaches it when the block exits. The formatter is ``"<LEVEL>: <message>"`` so doctest output
-    lines look like ``WARNING: Content mismatch ...``.
-    """
-    target_logger = logging.getLogger(logger_name)
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
-    handler.setLevel(level)
-    old_level = target_logger.level
-    target_logger.addHandler(handler)
-    target_logger.setLevel(level)
-    try:
-        yield
-    finally:
-        target_logger.removeHandler(handler)
-        target_logger.setLevel(old_level)
-
-
 @pytest.fixture(autouse=True)
-def _doctest_globals(doctest_namespace: dict) -> None:
+def _doctest_globals(doctest_namespace: dict, caplog: pytest.LogCaptureFixture) -> None:
     doctest_namespace["Path"] = Path
     doctest_namespace["json"] = json
-    doctest_namespace["capture_log_to_stdout"] = capture_log_to_stdout
+    doctest_namespace["caplog"] = caplog

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,21 @@
+"""Root conftest: inject common names into the doctest namespace.
+
+The ``yaml_to_disk`` and ``pretty_print_directory`` packages each ship a pytest plugin that registers
+``yaml_disk`` / ``print_directory`` / ``PrintConfig`` for use in doctests without explicit imports.
+This file extends that pattern for ``Path`` and ``json`` so module-level doctests don't have to spend
+their first line on ``>>> from pathlib import Path`` etc.
+
+Per-module behavioral fixtures still live in ``tests/conftest.py`` — this file only covers the
+doctest namespace.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _doctest_globals(doctest_namespace: dict) -> None:
+    doctest_namespace["Path"] = Path
+    doctest_namespace["json"] = json

--- a/conftest.py
+++ b/conftest.py
@@ -2,20 +2,48 @@
 
 The ``yaml_to_disk`` and ``pretty_print_directory`` packages each ship a pytest plugin that registers
 ``yaml_disk`` / ``print_directory`` / ``PrintConfig`` for use in doctests without explicit imports.
-This file extends that pattern for ``Path`` and ``json`` so module-level doctests don't have to spend
-their first line on ``>>> from pathlib import Path`` etc.
+This file extends that pattern for ``Path``, ``json``, and ``capture_log_to_stdout`` so module-level
+doctests don't have to spend their first line on boilerplate imports / setup.
 
 Per-module behavioral fixtures still live in ``tests/conftest.py`` — this file only covers the
 doctest namespace.
 """
 
+import contextlib
 import json
+import logging
+import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
+
+
+@contextlib.contextmanager
+def capture_log_to_stdout(logger_name: str, level: int = logging.INFO) -> Iterator[None]:
+    """Route a logger to ``sys.stdout`` so its messages are visible in doctest output.
+
+    Doctests don't have pytest's ``caplog`` fixture; assertions on log output have to round-trip
+    through stdout. This context manager attaches a temporary handler at the given level, then
+    detaches it when the block exits. The formatter is ``"<LEVEL>: <message>"`` so doctest output
+    lines look like ``WARNING: Content mismatch ...``.
+    """
+    target_logger = logging.getLogger(logger_name)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    handler.setLevel(level)
+    old_level = target_logger.level
+    target_logger.addHandler(handler)
+    target_logger.setLevel(level)
+    try:
+        yield
+    finally:
+        target_logger.removeHandler(handler)
+        target_logger.setLevel(old_level)
 
 
 @pytest.fixture(autouse=True)
 def _doctest_globals(doctest_namespace: dict) -> None:
     doctest_namespace["Path"] = Path
     doctest_namespace["json"] = json
+    doctest_namespace["capture_log_to_stdout"] = capture_log_to_stdout

--- a/conftest.py
+++ b/conftest.py
@@ -2,17 +2,47 @@
 
 The ``yaml_to_disk`` and ``pretty_print_directory`` packages each ship a pytest plugin that registers
 ``yaml_disk`` / ``print_directory`` / ``PrintConfig`` for use in doctests without explicit imports.
-This file extends that pattern for ``Path``, ``json``, and pytest's ``caplog`` fixture, so doctests
-that need to assert on log output can use the standard pytest mechanism without leaving the doctest.
+This file extends that pattern for ``Path``, ``json``, and two log-related helpers:
+
+- pytest's ``caplog`` fixture, for assertion-style checks on log records.
+- ``capture_log_to_stdout``, a context manager that routes a logger to ``sys.stdout`` so log
+    messages appear inline in the doctest output. Use this when the log message is part of the
+    documented contract — readers see the actual log line, not just a programmatic assertion that
+    one was emitted.
 
 Per-module behavioral fixtures still live in ``tests/conftest.py`` — this file only covers the
 doctest namespace.
 """
 
+import contextlib
 import json
+import logging
+import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
+
+
+@contextlib.contextmanager
+def capture_log_to_stdout(logger_name: str, level: int = logging.INFO) -> Iterator[None]:
+    """Route a logger to ``sys.stdout`` for the duration of the context.
+
+    Output lines are formatted as ``<LEVEL>: <message>`` so they're easy to match in doctests via
+    ELLIPSIS for the variable parts.
+    """
+    target_logger = logging.getLogger(logger_name)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    handler.setLevel(level)
+    old_level = target_logger.level
+    target_logger.addHandler(handler)
+    target_logger.setLevel(level)
+    try:
+        yield
+    finally:
+        target_logger.removeHandler(handler)
+        target_logger.setLevel(old_level)
 
 
 @pytest.fixture(autouse=True)
@@ -20,3 +50,4 @@ def _doctest_globals(doctest_namespace: dict, caplog: pytest.LogCaptureFixture) 
     doctest_namespace["Path"] = Path
     doctest_namespace["json"] = json
     doctest_namespace["caplog"] = caplog
+    doctest_namespace["capture_log_to_stdout"] = capture_log_to_stdout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,15 @@ classifiers = [
 dependencies = ["meds==0.3.3", "es-aces==0.6.1", "hydra-core", "meds-evaluation==0.0.3", "validators", "uv"]
 
 [dependency-groups]
-dev = ["pre-commit<4", "ruff", "pytest", "pytest-cov", "meds_testing_helpers"]
+dev = [
+  "pre-commit<4",
+  "ruff",
+  "pytest",
+  "pytest-cov",
+  "meds_testing_helpers",
+  "yaml-to-disk",
+  "pretty-print-directory",
+]
 
 [tool.setuptools_scm]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ dev = [
 
 [tool.setuptools_scm]
 
+[tool.coverage.run]
+patch = ["subprocess"]
+
 [tool.coverage.report]
 omit = ["*/models/cehrbert/*"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ omit = ["*/models/cehrbert/*"]
 addopts = [
   "--color=yes",
 ]
+doctest_optionflags = "ELLIPSIS NORMALIZE_WHITESPACE"
 markers = [
   "integration: end-to-end tests that build datasets, run tasks, create model envs, or run evaluations",
 ]
@@ -53,6 +54,8 @@ meds-dev-model = "MEDS_DEV.models.__main__:main"
 meds-dev-evaluation = "MEDS_DEV.evaluation.__main__:main"
 meds-dev-pack-result = "MEDS_DEV.results.__main__:pack_result"
 meds-dev-validate-result = "MEDS_DEV.results.__main__:validate_result"
+meds-dev-collate-entities = "MEDS_DEV.web.collate_entities:main"
+meds-dev-aggregate-results = "MEDS_DEV.web.aggregate_results:main"
 
 [project.urls]
 Homepage = "https://github.com/Medical-Event-Data-Standard/MEDS-DEV"

--- a/src/MEDS_DEV/web/__init__.py
+++ b/src/MEDS_DEV/web/__init__.py
@@ -1,0 +1,6 @@
+"""Web tooling: collate entities and aggregate results for the MEDS-DEV website."""
+
+from .aggregate_results import aggregate_results
+from .collate_entities import collate_entities
+
+__all__ = ["aggregate_results", "collate_entities"]

--- a/src/MEDS_DEV/web/aggregate_results.py
+++ b/src/MEDS_DEV/web/aggregate_results.py
@@ -29,8 +29,11 @@ def aggregate_results(
     output_path: Path,
     error_threshold: int = 10,
     do_overwrite: bool = False,
-) -> dict[str, Any]:
+) -> None:
     """Aggregate ``result.json`` files under ``input_dir`` into ``output_path``.
+
+    The function is side-effecting: it writes the aggregated JSON to ``output_path`` and returns
+    nothing. Callers (including doctests below) inspect the result by reading the file back.
 
     Args:
         input_dir: Directory whose subdirectories each contain a ``result.json``. The subdirectory
@@ -40,9 +43,6 @@ def aggregate_results(
         do_overwrite: If ``False`` (default) and ``output_path`` already exists, its existing
             entries are preserved as-is; only keys not present are added. If ``True``, the existing
             output is ignored and the aggregate is rebuilt from scratch.
-
-    Returns:
-        The full aggregated dict that was written.
 
     Raises:
         FileNotFoundError: If ``input_dir`` does not exist or contains no ``result.json`` files.
@@ -57,11 +57,17 @@ def aggregate_results(
         ...     "200": {"result.json": {"result": "data 200"}},
         ... }
         >>> with yaml_disk(tree) as d:
-        ...     agg = aggregate_results(d, d / "all_results.json")
-        ...     sorted(agg.keys())
-        ['200', '44']
-        >>> agg["44"]
-        {'result': 'data 44'}
+        ...     out = d / "all_results.json"
+        ...     aggregate_results(d, out)
+        ...     print(out.read_text())
+        {
+          "200": {
+            "result": "data 200"
+          },
+          "44": {
+            "result": "data 44"
+          }
+        }
 
         New keys are added on subsequent runs, but pre-existing keys are not refreshed. This is
         deliberate — each ``result.json`` is the canonical record for one experiment, and
@@ -72,24 +78,27 @@ def aggregate_results(
 
         >>> with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
         ...     out = d / "all_results.json"
-        ...     _ = aggregate_results(d, out)
+        ...     aggregate_results(d, out)
+        ...     print("after first call: ", json.loads(out.read_text()))
         ...     # Mutate the source AND add a new issue:
         ...     _ = (d / "1" / "result.json").write_text('{"result": "v2"}')
         ...     _ = (d / "2").mkdir()
         ...     _ = (d / "2" / "result.json").write_text('{"result": "new"}')
-        ...     agg = aggregate_results(d, out)
-        ...     agg["1"], agg["2"]
-        ({'result': 'v1'}, {'result': 'new'})
+        ...     aggregate_results(d, out)
+        ...     print("after second call:", json.loads(out.read_text()))
+        after first call:  {'1': {'result': 'v1'}}
+        after second call: {'1': {'result': 'v1'}, '2': {'result': 'new'}}
 
         When the on-disk source HAS legitimately changed (corrupted past run, manual edit to a
         result.json that should propagate), pass ``do_overwrite=True`` to rebuild from scratch:
 
         >>> with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
         ...     out = d / "all_results.json"
-        ...     _ = aggregate_results(d, out)
+        ...     aggregate_results(d, out)
         ...     _ = (d / "1" / "result.json").write_text('{"result": "v2"}')
-        ...     aggregate_results(d, out, do_overwrite=True)["1"]
-        {'result': 'v2'}
+        ...     aggregate_results(d, out, do_overwrite=True)
+        ...     json.loads(out.read_text())
+        {'1': {'result': 'v2'}}
 
     Errors:
 
@@ -107,6 +116,17 @@ def aggregate_results(
         Traceback (most recent call last):
             ...
         FileNotFoundError: No result.json files found under ...
+
+        Parse failures count toward ``error_threshold``; exceed it and aggregation aborts:
+
+        >>> tree = {str(i): {"result.json": {"placeholder": True}} for i in range(5)}
+        >>> with yaml_disk(tree) as d:
+        ...     for i in range(5):
+        ...         _ = (d / str(i) / "result.json").write_text("{not valid json")
+        ...     aggregate_results(d, d / "o.json", error_threshold=2)
+        Traceback (most recent call last):
+            ...
+        ValueError: Too many parse errors (3 > 2); aborting.
     """
     if not input_dir.exists():
         raise FileNotFoundError(f"Input directory {input_dir.resolve()!s} does not exist.")
@@ -157,7 +177,6 @@ def aggregate_results(
     logger.info(
         f"Wrote {len(results)} results ({new_results} new, {len(parse_errors)} errors) to {output_path}"
     )
-    return results
 
 
 def main() -> None:

--- a/src/MEDS_DEV/web/aggregate_results.py
+++ b/src/MEDS_DEV/web/aggregate_results.py
@@ -36,31 +36,25 @@ def aggregate_results(input_dir: Path, output_path: Path, error_threshold: int =
         ValueError: If parse failures exceed ``error_threshold``.
 
     Examples:
-        >>> import json, tempfile
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     d = Path(d)
-        ...     for issue in ("44", "200"):
-        ...         (d / issue).mkdir()
-        ...         _ = (d / issue / "result.json").write_text(json.dumps({"result": f"data {issue}"}))
-        ...     out = d / "all_results.json"
-        ...     agg = aggregate_results(d, out)
+        >>> tree = {
+        ...     "44": {"result.json": {"result": "data 44"}},
+        ...     "200": {"result.json": {"result": "data 200"}},
+        ... }
+        >>> with yaml_disk(tree) as d:
+        ...     agg = aggregate_results(d, d / "all_results.json")
         ...     sorted(agg.keys())
         ['200', '44']
         >>> agg["44"]
         {'result': 'data 44'}
 
-    A second call with the same input is a no-op (existing keys preserved, no new keys to add):
+    A second call with the same input is a no-op (existing keys preserved, no new keys to add). Even
+    if the on-disk source changes after the first run, the previously-aggregated entry sticks:
 
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     d = Path(d)
-        ...     (d / "1").mkdir()
-        ...     _ = (d / "1" / "result.json").write_text('{"result": "v1"}')
+        >>> with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
         ...     out = d / "all_results.json"
         ...     _ = aggregate_results(d, out)
-        ...     # Now "modify" the source — aggregator should NOT re-read; it preserves existing.
         ...     _ = (d / "1" / "result.json").write_text('{"result": "v2"}')
-        ...     agg = aggregate_results(d, out)
-        ...     agg["1"]
+        ...     aggregate_results(d, out)["1"]
         {'result': 'v1'}
 
     Errors:
@@ -69,14 +63,13 @@ def aggregate_results(input_dir: Path, output_path: Path, error_threshold: int =
         Traceback (most recent call last):
             ...
         FileNotFoundError: Input directory ... does not exist.
-        >>> import tempfile
-        >>> with tempfile.NamedTemporaryFile() as f:
-        ...     aggregate_results(Path(f.name), Path("/tmp/o.json"))
+        >>> with yaml_disk({"a.txt": "scalar"}) as d:
+        ...     aggregate_results(d / "a.txt", d / "o.json")
         Traceback (most recent call last):
             ...
         NotADirectoryError: Input path ... is not a directory.
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     aggregate_results(Path(d), Path(d) / "o.json")
+        >>> with yaml_disk({"no_results.txt": "unrelated"}) as d:
+        ...     aggregate_results(d, d / "o.json")
         Traceback (most recent call last):
             ...
         FileNotFoundError: No result.json files found under ...

--- a/src/MEDS_DEV/web/aggregate_results.py
+++ b/src/MEDS_DEV/web/aggregate_results.py
@@ -4,8 +4,12 @@ Each benchmark submission lives at ``_results/<issue_number>/result.json`` on th
 branch. The MEDS-DEV website consumes a single aggregated file at ``_web/results/all_results.json``,
 keyed by issue number.
 
-This module produces that aggregate. If the output file already exists, existing entries are preserved
-and only new issue numbers are added — making the script idempotent and append-only.
+Default behavior is append-only: existing keys in the output file are preserved as-is, and new keys
+from the input directory are added. Each ``result.json`` represents one canonical experimental
+result, so once a submission has been aggregated, re-running the aggregator should not silently
+mutate that entry. Use ``do_overwrite=True`` (CLI: ``--do_overwrite``) when you need to rebuild from
+scratch — e.g., after a corrupted past run, or when a ``result.json`` has been intentionally edited
+in place and the new content should propagate.
 """
 
 import argparse
@@ -17,15 +21,22 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-def aggregate_results(input_dir: Path, output_path: Path, error_threshold: int = 10) -> dict[str, Any]:
+def aggregate_results(
+    input_dir: Path,
+    output_path: Path,
+    error_threshold: int = 10,
+    do_overwrite: bool = False,
+) -> dict[str, Any]:
     """Aggregate ``result.json`` files under ``input_dir`` into ``output_path``.
 
     Args:
         input_dir: Directory whose subdirectories each contain a ``result.json``. The subdirectory
             name (typically a GitHub issue number) becomes the aggregate key.
-        output_path: Path to write the aggregated JSON to. If the file already exists, its existing
-            entries are preserved and only new keys are added.
+        output_path: Path to write the aggregated JSON to.
         error_threshold: Maximum number of per-file parse failures tolerated before aborting.
+        do_overwrite: If ``False`` (default) and ``output_path`` already exists, its existing
+            entries are preserved as-is; only keys not present are added. If ``True``, the existing
+            output is ignored and the aggregate is rebuilt from scratch.
 
     Returns:
         The full aggregated dict that was written.
@@ -36,6 +47,8 @@ def aggregate_results(input_dir: Path, output_path: Path, error_threshold: int =
         ValueError: If parse failures exceed ``error_threshold``.
 
     Examples:
+        The happy path — every result.json under input gets a corresponding key in the output:
+
         >>> tree = {
         ...     "44": {"result.json": {"result": "data 44"}},
         ...     "200": {"result.json": {"result": "data 200"}},
@@ -47,15 +60,30 @@ def aggregate_results(input_dir: Path, output_path: Path, error_threshold: int =
         >>> agg["44"]
         {'result': 'data 44'}
 
-    A second call with the same input is a no-op (existing keys preserved, no new keys to add). Even
-    if the on-disk source changes after the first run, the previously-aggregated entry sticks:
+        New keys are added on subsequent runs, but pre-existing keys are not refreshed. This is
+        deliberate — each ``result.json`` is the canonical record for one experiment, and
+        re-aggregation should not silently mutate already-canonical entries:
+
+        >>> with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
+        ...     out = d / "all_results.json"
+        ...     _ = aggregate_results(d, out)
+        ...     # Mutate the source AND add a new issue:
+        ...     _ = (d / "1" / "result.json").write_text('{"result": "v2"}')
+        ...     _ = (d / "2").mkdir()
+        ...     _ = (d / "2" / "result.json").write_text('{"result": "new"}')
+        ...     agg = aggregate_results(d, out)
+        ...     agg["1"], agg["2"]
+        ({'result': 'v1'}, {'result': 'new'})
+
+        When the on-disk source HAS legitimately changed (corrupted past run, manual edit to a
+        result.json that should propagate), pass ``do_overwrite=True`` to rebuild from scratch:
 
         >>> with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
         ...     out = d / "all_results.json"
         ...     _ = aggregate_results(d, out)
         ...     _ = (d / "1" / "result.json").write_text('{"result": "v2"}')
-        ...     aggregate_results(d, out)["1"]
-        {'result': 'v1'}
+        ...     aggregate_results(d, out, do_overwrite=True)["1"]
+        {'result': 'v2'}
 
     Errors:
 
@@ -79,7 +107,10 @@ def aggregate_results(input_dir: Path, output_path: Path, error_threshold: int =
     if not input_dir.is_dir():
         raise NotADirectoryError(f"Input path {input_dir.resolve()!s} is not a directory.")
 
-    results: dict[str, Any] = json.loads(output_path.read_text()) if output_path.exists() else {}
+    if do_overwrite or not output_path.exists():
+        results: dict[str, Any] = {}
+    else:
+        results = json.loads(output_path.read_text())
 
     result_fps = sorted(input_dir.rglob("result.json"))
     if not result_fps:
@@ -90,14 +121,14 @@ def aggregate_results(input_dir: Path, output_path: Path, error_threshold: int =
     for result_fp in result_fps:
         issue_num = result_fp.parent.name
         if issue_num in results:
-            logger.info("Skipping %s (already aggregated)", issue_num)
+            logger.info(f"Skipping {issue_num} (already aggregated)")
             continue
         try:
             results[issue_num] = json.loads(result_fp.read_text())
             new_results += 1
         except (json.JSONDecodeError, OSError) as e:
             err = f"{result_fp}: {e}"
-            logger.warning("Failed to read %s", err)
+            logger.warning(f"Failed to read {err}")
             parse_errors.append(err)
             if len(parse_errors) > error_threshold:
                 raise ValueError(
@@ -107,11 +138,7 @@ def aggregate_results(input_dir: Path, output_path: Path, error_threshold: int =
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True))
     logger.info(
-        "Wrote %d results (%d new, %d errors) to %s",
-        len(results),
-        new_results,
-        len(parse_errors),
-        output_path,
+        f"Wrote {len(results)} results ({new_results} new, {len(parse_errors)} errors) to {output_path}"
     )
     return results
 
@@ -136,5 +163,13 @@ def main() -> None:
         default=10,
         help="Max per-file parse failures before aborting (default: 10).",
     )
+    parser.add_argument(
+        "--do_overwrite",
+        action="store_true",
+        help=(
+            "Ignore any existing output file and rebuild the aggregate from scratch. Default is "
+            "append-only (existing keys preserved)."
+        ),
+    )
     args = parser.parse_args()
-    aggregate_results(args.input_dir, args.output_path, args.error_threshold)
+    aggregate_results(args.input_dir, args.output_path, args.error_threshold, args.do_overwrite)

--- a/src/MEDS_DEV/web/aggregate_results.py
+++ b/src/MEDS_DEV/web/aggregate_results.py
@@ -1,0 +1,151 @@
+"""Aggregate per-issue benchmark result JSON files into a single ``all_results.json`` blob.
+
+Each benchmark submission lives at ``_results/<issue_number>/result.json`` on the ``_results`` orphan
+branch. The MEDS-DEV website consumes a single aggregated file at ``_web/results/all_results.json``,
+keyed by issue number.
+
+This module produces that aggregate. If the output file already exists, existing entries are preserved
+and only new issue numbers are added — making the script idempotent and append-only.
+"""
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def aggregate_results(input_dir: Path, output_path: Path, error_threshold: int = 10) -> dict[str, Any]:
+    """Aggregate ``result.json`` files under ``input_dir`` into ``output_path``.
+
+    Args:
+        input_dir: Directory whose subdirectories each contain a ``result.json``. The subdirectory
+            name (typically a GitHub issue number) becomes the aggregate key.
+        output_path: Path to write the aggregated JSON to. If the file already exists, its existing
+            entries are preserved and only new keys are added.
+        error_threshold: Maximum number of per-file parse failures tolerated before aborting.
+
+    Returns:
+        The full aggregated dict that was written.
+
+    Raises:
+        FileNotFoundError: If ``input_dir`` does not exist or contains no ``result.json`` files.
+        NotADirectoryError: If ``input_dir`` is not a directory.
+        ValueError: If parse failures exceed ``error_threshold``.
+
+    Examples:
+        >>> import json, tempfile
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     d = Path(d)
+        ...     for issue in ("44", "200"):
+        ...         (d / issue).mkdir()
+        ...         _ = (d / issue / "result.json").write_text(json.dumps({"result": f"data {issue}"}))
+        ...     out = d / "all_results.json"
+        ...     agg = aggregate_results(d, out)
+        ...     sorted(agg.keys())
+        ['200', '44']
+        >>> agg["44"]
+        {'result': 'data 44'}
+
+    A second call with the same input is a no-op (existing keys preserved, no new keys to add):
+
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     d = Path(d)
+        ...     (d / "1").mkdir()
+        ...     _ = (d / "1" / "result.json").write_text('{"result": "v1"}')
+        ...     out = d / "all_results.json"
+        ...     _ = aggregate_results(d, out)
+        ...     # Now "modify" the source — aggregator should NOT re-read; it preserves existing.
+        ...     _ = (d / "1" / "result.json").write_text('{"result": "v2"}')
+        ...     agg = aggregate_results(d, out)
+        ...     agg["1"]
+        {'result': 'v1'}
+
+    Errors:
+
+        >>> aggregate_results(Path("/nonexistent_xyz"), Path("/tmp/o.json"))
+        Traceback (most recent call last):
+            ...
+        FileNotFoundError: Input directory ... does not exist.
+        >>> import tempfile
+        >>> with tempfile.NamedTemporaryFile() as f:
+        ...     aggregate_results(Path(f.name), Path("/tmp/o.json"))
+        Traceback (most recent call last):
+            ...
+        NotADirectoryError: Input path ... is not a directory.
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     aggregate_results(Path(d), Path(d) / "o.json")
+        Traceback (most recent call last):
+            ...
+        FileNotFoundError: No result.json files found under ...
+    """
+    if not input_dir.exists():
+        raise FileNotFoundError(f"Input directory {input_dir.resolve()!s} does not exist.")
+    if not input_dir.is_dir():
+        raise NotADirectoryError(f"Input path {input_dir.resolve()!s} is not a directory.")
+
+    results: dict[str, Any] = json.loads(output_path.read_text()) if output_path.exists() else {}
+
+    result_fps = sorted(input_dir.rglob("result.json"))
+    if not result_fps:
+        raise FileNotFoundError(f"No result.json files found under {input_dir.resolve()!s}.")
+
+    parse_errors: list[str] = []
+    new_results = 0
+    for result_fp in result_fps:
+        issue_num = result_fp.parent.name
+        if issue_num in results:
+            logger.info("Skipping %s (already aggregated)", issue_num)
+            continue
+        try:
+            results[issue_num] = json.loads(result_fp.read_text())
+            new_results += 1
+        except (json.JSONDecodeError, OSError) as e:
+            err = f"{result_fp}: {e}"
+            logger.warning("Failed to read %s", err)
+            parse_errors.append(err)
+            if len(parse_errors) > error_threshold:
+                raise ValueError(
+                    f"Too many parse errors ({len(parse_errors)} > {error_threshold}); aborting."
+                ) from e
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(results, indent=2, sort_keys=True))
+    logger.info(
+        "Wrote %d results (%d new, %d errors) to %s",
+        len(results),
+        new_results,
+        len(parse_errors),
+        output_path,
+    )
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Aggregate per-issue MEDS-DEV result JSON blobs.")
+    parser.add_argument(
+        "--input_dir",
+        type=Path,
+        default=Path("_results"),
+        help="Directory containing <issue_number>/result.json subdirectories (default: _results).",
+    )
+    parser.add_argument(
+        "--output_path",
+        type=Path,
+        default=Path("all_results.json"),
+        help="Path to the aggregated JSON file (default: all_results.json).",
+    )
+    parser.add_argument(
+        "--error_threshold",
+        type=int,
+        default=10,
+        help="Max per-file parse failures before aborting (default: 10).",
+    )
+    args = parser.parse_args()
+    aggregate_results(args.input_dir, args.output_path, args.error_threshold)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/MEDS_DEV/web/aggregate_results.py
+++ b/src/MEDS_DEV/web/aggregate_results.py
@@ -7,9 +7,12 @@ keyed by issue number.
 Default behavior is append-only: existing keys in the output file are preserved as-is, and new keys
 from the input directory are added. Each ``result.json`` represents one canonical experimental
 result, so once a submission has been aggregated, re-running the aggregator should not silently
-mutate that entry. Use ``do_overwrite=True`` (CLI: ``--do_overwrite``) when you need to rebuild from
-scratch — e.g., after a corrupted past run, or when a ``result.json`` has been intentionally edited
-in place and the new content should propagate.
+mutate that entry.
+
+If a result.json's on-disk content has drifted from the aggregated entry (e.g., past corrupted run,
+manual edit), the aggregator logs a loud warning but keeps the existing entry — silent drift is
+worse than a noisy diagnostic. Pass ``do_overwrite=True`` (CLI: ``--do_overwrite``) to ignore the
+existing aggregate and rebuild from scratch.
 """
 
 import argparse
@@ -62,7 +65,10 @@ def aggregate_results(
 
         New keys are added on subsequent runs, but pre-existing keys are not refreshed. This is
         deliberate — each ``result.json`` is the canonical record for one experiment, and
-        re-aggregation should not silently mutate already-canonical entries:
+        re-aggregation should not silently mutate already-canonical entries. If the on-disk
+        ``result.json`` content has drifted from the aggregated entry, a loud warning is emitted
+        (see ``test_aggregate_results_warns_on_content_mismatch`` in ``tests/test_web.py``) but the
+        existing entry is kept:
 
         >>> with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
         ...     out = d / "all_results.json"
@@ -120,12 +126,8 @@ def aggregate_results(
     new_results = 0
     for result_fp in result_fps:
         issue_num = result_fp.parent.name
-        if issue_num in results:
-            logger.info(f"Skipping {issue_num} (already aggregated)")
-            continue
         try:
-            results[issue_num] = json.loads(result_fp.read_text())
-            new_results += 1
+            new_content = json.loads(result_fp.read_text())
         except (json.JSONDecodeError, OSError) as e:
             err = f"{result_fp}: {e}"
             logger.warning(f"Failed to read {err}")
@@ -134,6 +136,21 @@ def aggregate_results(
                 raise ValueError(
                     f"Too many parse errors ({len(parse_errors)} > {error_threshold}); aborting."
                 ) from e
+            continue
+
+        if issue_num in results:
+            if results[issue_num] != new_content:
+                logger.warning(
+                    f"Content mismatch for issue {issue_num}: aggregated entry in {output_path} "
+                    f"does not match on-disk {result_fp}. Keeping the existing aggregated entry; "
+                    f"pass do_overwrite=True to rebuild from scratch."
+                )
+            else:
+                logger.info(f"Skipping {issue_num} (already aggregated)")
+            continue
+
+        results[issue_num] = new_content
+        new_results += 1
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(results, indent=2, sort_keys=True))

--- a/src/MEDS_DEV/web/aggregate_results.py
+++ b/src/MEDS_DEV/web/aggregate_results.py
@@ -145,7 +145,3 @@ def main() -> None:
     )
     args = parser.parse_args()
     aggregate_results(args.input_dir, args.output_path, args.error_threshold)
-
-
-if __name__ == "__main__":  # pragma: no cover
-    main()

--- a/src/MEDS_DEV/web/aggregate_results.py
+++ b/src/MEDS_DEV/web/aggregate_results.py
@@ -147,5 +147,5 @@ def main() -> None:
     aggregate_results(args.input_dir, args.output_path, args.error_threshold)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/src/MEDS_DEV/web/aggregate_results.py
+++ b/src/MEDS_DEV/web/aggregate_results.py
@@ -73,10 +73,10 @@ def aggregate_results(
         deliberate — each ``result.json`` is the canonical record for one experiment, and
         re-aggregation should not silently mutate already-canonical entries. If the on-disk
         ``result.json`` content has drifted from the aggregated entry, a loud warning is emitted
-        (see ``test_aggregate_results_warns_on_content_mismatch`` in ``tests/test_web.py``) but the
-        existing entry is kept:
+        but the existing entry is kept:
 
-        >>> with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
+        >>> with capture_log_to_stdout(__name__):
+        ...   with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
         ...     out = d / "all_results.json"
         ...     aggregate_results(d, out)
         ...     print("after first call: ", json.loads(out.read_text()))
@@ -86,8 +86,23 @@ def aggregate_results(
         ...     _ = (d / "2" / "result.json").write_text('{"result": "new"}')
         ...     aggregate_results(d, out)
         ...     print("after second call:", json.loads(out.read_text()))
+        INFO: Wrote 1 results (1 new, 0 errors) to ...
         after first call:  {'1': {'result': 'v1'}}
+        WARNING: Content mismatch for issue 1: ... Keeping the existing aggregated entry; ...
+        INFO: Wrote 2 results (1 new, 0 errors) to ...
         after second call: {'1': {'result': 'v1'}, '2': {'result': 'new'}}
+
+        Repeating the run with the source unchanged is a silent no-op apart from an info-level
+        "already aggregated" log line per matching key:
+
+        >>> with capture_log_to_stdout(__name__):
+        ...   with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
+        ...     out = d / "all_results.json"
+        ...     aggregate_results(d, out)
+        ...     aggregate_results(d, out)
+        INFO: Wrote 1 results (1 new, 0 errors) to ...
+        INFO: Skipping 1 (already aggregated)
+        INFO: Wrote 1 results (0 new, 0 errors) to ...
 
         When the on-disk source HAS legitimately changed (corrupted past run, manual edit to a
         result.json that should propagate), pass ``do_overwrite=True`` to rebuild from scratch:
@@ -99,6 +114,20 @@ def aggregate_results(
         ...     aggregate_results(d, out, do_overwrite=True)
         ...     json.loads(out.read_text())
         {'1': {'result': 'v2'}}
+
+        A malformed ``result.json`` is logged at WARNING level and skipped; valid blobs in the same
+        run are still aggregated:
+
+        >>> with capture_log_to_stdout(__name__):
+        ...   with yaml_disk({"1": {"result.json": {"valid": "json"}}}) as d:
+        ...     _ = (d / "2").mkdir()
+        ...     _ = (d / "2" / "result.json").write_text("{not valid json")
+        ...     out = d / "all_results.json"
+        ...     aggregate_results(d, out)
+        ...     print(json.loads(out.read_text()))
+        WARNING: Failed to read ...result.json: ...
+        INFO: Wrote 1 results (1 new, 1 errors) to ...
+        {'1': {'valid': 'json'}}
 
     Errors:
 

--- a/src/MEDS_DEV/web/aggregate_results.py
+++ b/src/MEDS_DEV/web/aggregate_results.py
@@ -75,34 +75,32 @@ def aggregate_results(
         ``result.json`` content has drifted from the aggregated entry, a loud warning is emitted
         but the existing entry is kept:
 
-        >>> with capture_log_to_stdout(__name__):
+        >>> caplog.clear()
+        >>> with caplog.at_level("WARNING", logger=__name__):
         ...   with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
         ...     out = d / "all_results.json"
         ...     aggregate_results(d, out)
-        ...     print("after first call: ", json.loads(out.read_text()))
         ...     # Mutate the source AND add a new issue:
         ...     _ = (d / "1" / "result.json").write_text('{"result": "v2"}')
         ...     _ = (d / "2").mkdir()
         ...     _ = (d / "2" / "result.json").write_text('{"result": "new"}')
         ...     aggregate_results(d, out)
-        ...     print("after second call:", json.loads(out.read_text()))
-        INFO: Wrote 1 results (1 new, 0 errors) to ...
-        after first call:  {'1': {'result': 'v1'}}
-        WARNING: Content mismatch for issue 1: ... Keeping the existing aggregated entry; ...
-        INFO: Wrote 2 results (1 new, 0 errors) to ...
-        after second call: {'1': {'result': 'v1'}, '2': {'result': 'new'}}
+        ...     print(json.loads(out.read_text()))
+        {'1': {'result': 'v1'}, '2': {'result': 'new'}}
+        >>> [r.message for r in caplog.records if "Content mismatch" in r.message]
+        ['Content mismatch for issue 1: ... Keeping the existing aggregated entry; ...']
 
         Repeating the run with the source unchanged is a silent no-op apart from an info-level
         "already aggregated" log line per matching key:
 
-        >>> with capture_log_to_stdout(__name__):
+        >>> caplog.clear()
+        >>> with caplog.at_level("INFO", logger=__name__):
         ...   with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
         ...     out = d / "all_results.json"
         ...     aggregate_results(d, out)
         ...     aggregate_results(d, out)
-        INFO: Wrote 1 results (1 new, 0 errors) to ...
-        INFO: Skipping 1 (already aggregated)
-        INFO: Wrote 1 results (0 new, 0 errors) to ...
+        >>> [r.message for r in caplog.records if "already aggregated" in r.message]
+        ['Skipping 1 (already aggregated)']
 
         When the on-disk source HAS legitimately changed (corrupted past run, manual edit to a
         result.json that should propagate), pass ``do_overwrite=True`` to rebuild from scratch:
@@ -118,16 +116,17 @@ def aggregate_results(
         A malformed ``result.json`` is logged at WARNING level and skipped; valid blobs in the same
         run are still aggregated:
 
-        >>> with capture_log_to_stdout(__name__):
+        >>> caplog.clear()
+        >>> with caplog.at_level("WARNING", logger=__name__):
         ...   with yaml_disk({"1": {"result.json": {"valid": "json"}}}) as d:
         ...     _ = (d / "2").mkdir()
         ...     _ = (d / "2" / "result.json").write_text("{not valid json")
         ...     out = d / "all_results.json"
         ...     aggregate_results(d, out)
         ...     print(json.loads(out.read_text()))
-        WARNING: Failed to read ...result.json: ...
-        INFO: Wrote 1 results (1 new, 1 errors) to ...
         {'1': {'valid': 'json'}}
+        >>> any("Failed to read" in r.message for r in caplog.records)
+        True
 
     Errors:
 

--- a/src/MEDS_DEV/web/aggregate_results.py
+++ b/src/MEDS_DEV/web/aggregate_results.py
@@ -69,38 +69,38 @@ def aggregate_results(
           }
         }
 
+        Repeating the run with the source unchanged is a silent no-op apart from an info-level
+        "already aggregated" log line per matching key:
+
+        >>> with capture_log_to_stdout(__name__):
+        ...   with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
+        ...     out = d / "all_results.json"
+        ...     aggregate_results(d, out)
+        ...     aggregate_results(d, out)
+        INFO: Wrote 1 results (1 new, 0 errors) to ...
+        INFO: Skipping 1 (already aggregated)
+        INFO: Wrote 1 results (0 new, 0 errors) to ...
+
         New keys are added on subsequent runs, but pre-existing keys are not refreshed. This is
         deliberate — each ``result.json`` is the canonical record for one experiment, and
         re-aggregation should not silently mutate already-canonical entries. If the on-disk
         ``result.json`` content has drifted from the aggregated entry, a loud warning is emitted
         but the existing entry is kept:
 
-        >>> caplog.clear()
-        >>> with caplog.at_level("WARNING", logger=__name__):
+        >>> with capture_log_to_stdout(__name__, logging.WARNING):
         ...   with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
         ...     out = d / "all_results.json"
         ...     aggregate_results(d, out)
+        ...     print("after first call: ", json.loads(out.read_text()))
         ...     # Mutate the source AND add a new issue:
         ...     _ = (d / "1" / "result.json").write_text('{"result": "v2"}')
         ...     _ = (d / "2").mkdir()
         ...     _ = (d / "2" / "result.json").write_text('{"result": "new"}')
         ...     aggregate_results(d, out)
-        ...     print(json.loads(out.read_text()))
-        {'1': {'result': 'v1'}, '2': {'result': 'new'}}
-        >>> [r.message for r in caplog.records if "Content mismatch" in r.message]
-        ['Content mismatch for issue 1: ... Keeping the existing aggregated entry; ...']
-
-        Repeating the run with the source unchanged is a silent no-op apart from an info-level
-        "already aggregated" log line per matching key:
-
-        >>> caplog.clear()
-        >>> with caplog.at_level("INFO", logger=__name__):
-        ...   with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
-        ...     out = d / "all_results.json"
-        ...     aggregate_results(d, out)
-        ...     aggregate_results(d, out)
-        >>> [r.message for r in caplog.records if "already aggregated" in r.message]
-        ['Skipping 1 (already aggregated)']
+        ...     print("after second call:", json.loads(out.read_text()))
+        after first call:  {'1': {'result': 'v1'}}
+        WARNING: Content mismatch for issue 1: ... Keeping the existing aggregated entry; ...
+        after second call: {'1': {'result': 'v1'}, '2': {'result': 'new'}}
 
         When the on-disk source HAS legitimately changed (corrupted past run, manual edit to a
         result.json that should propagate), pass ``do_overwrite=True`` to rebuild from scratch:
@@ -108,25 +108,25 @@ def aggregate_results(
         >>> with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
         ...     out = d / "all_results.json"
         ...     aggregate_results(d, out)
+        ...     print("before do_overwrite:", json.loads(out.read_text()))
         ...     _ = (d / "1" / "result.json").write_text('{"result": "v2"}')
         ...     aggregate_results(d, out, do_overwrite=True)
-        ...     json.loads(out.read_text())
-        {'1': {'result': 'v2'}}
+        ...     print("after do_overwrite: ", json.loads(out.read_text()))
+        before do_overwrite: {'1': {'result': 'v1'}}
+        after do_overwrite:  {'1': {'result': 'v2'}}
 
         A malformed ``result.json`` is logged at WARNING level and skipped; valid blobs in the same
         run are still aggregated:
 
-        >>> caplog.clear()
-        >>> with caplog.at_level("WARNING", logger=__name__):
+        >>> with capture_log_to_stdout(__name__, logging.WARNING):
         ...   with yaml_disk({"1": {"result.json": {"valid": "json"}}}) as d:
         ...     _ = (d / "2").mkdir()
         ...     _ = (d / "2" / "result.json").write_text("{not valid json")
         ...     out = d / "all_results.json"
         ...     aggregate_results(d, out)
         ...     print(json.loads(out.read_text()))
+        WARNING: Failed to read ...result.json: ...
         {'1': {'valid': 'json'}}
-        >>> any("Failed to read" in r.message for r in caplog.records)
-        True
 
     Errors:
 

--- a/src/MEDS_DEV/web/collate_entities.py
+++ b/src/MEDS_DEV/web/collate_entities.py
@@ -171,7 +171,9 @@ def _walk_ancestors(leaf: Path, root: Path) -> Iterator[Path]:
     parent = leaf.parent
     while parent != root:
         yield parent
-        if parent == parent.parent:  # pragma: no cover  # filesystem root reached
+        if parent == parent.parent:
+            # Filesystem root reached without ever finding ``root``. This means the caller passed a
+            # leaf that isn't under ``root`` — yield what we've found and stop instead of looping.
             return
         parent = parent.parent
 
@@ -399,7 +401,3 @@ def main() -> None:
     )
     args = parser.parse_args()
     collate_entities(args.repo_dir, args.output_dir, args.do_overwrite)
-
-
-if __name__ == "__main__":  # pragma: no cover
-    main()

--- a/src/MEDS_DEV/web/collate_entities.py
+++ b/src/MEDS_DEV/web/collate_entities.py
@@ -63,21 +63,17 @@ def _read_file(path: Path) -> Any:
     """Read a single file from a leaf directory, dispatching by extension.
 
     Examples:
-        >>> import tempfile
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     p = Path(d) / "predicates.yaml"
-        ...     _ = p.write_text("foo: bar\\n")
-        ...     _read_file(p)
+        >>> tree = {
+        ...     "predicates.yaml": {"foo": "bar"},
+        ...     "requirements.txt": "numpy==1.21.0\\npandas==2.0.0\\n",
+        ...     "README.md": "# Title\\n",
+        ... }
+        >>> with yaml_disk(tree) as d:
+        ...     _read_file(d / "predicates.yaml")
+        ...     _read_file(d / "requirements.txt")
+        ...     _read_file(d / "README.md")
         {'foo': 'bar'}
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     p = Path(d) / "requirements.txt"
-        ...     _ = p.write_text("numpy==1.21.0\\npandas==2.0.0\\n")
-        ...     _read_file(p)
         ['numpy==1.21.0', 'pandas==2.0.0']
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     p = Path(d) / "README.md"
-        ...     _ = p.write_text("# Title\\n")
-        ...     _read_file(p)
         '# Title\\n'
     """
     if path.suffix == ".yaml":
@@ -97,14 +93,15 @@ def _read_leaf_dir(leaf_dir: Path, entity_type: EntityType) -> dict[str, Any]:
     ``LEAF_FILES`` go under their mapped keys.
 
     Examples:
-        >>> import tempfile
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     leaf = Path(d) / "MIMIC-IV"
-        ...     leaf.mkdir()
-        ...     _ = (leaf / "dataset.yaml").write_text("metadata:\\n  description: foo\\n")
-        ...     _ = (leaf / "README.md").write_text("# MIMIC")
-        ...     _ = (leaf / "requirements.txt").write_text("meds==0.3.3\\n")
-        ...     data = _read_leaf_dir(leaf, "dataset")
+        >>> tree = {
+        ...     "MIMIC-IV/": {
+        ...         "dataset.yaml": {"metadata": {"description": "foo"}},
+        ...         "README.md": "# MIMIC",
+        ...         "requirements.txt": "meds==0.3.3\\n",
+        ...     }
+        ... }
+        >>> with yaml_disk(tree) as d:
+        ...     data = _read_leaf_dir(d / "MIMIC-IV", "dataset")
         ...     sorted(data.keys())
         ['entity', 'readme', 'requirements', 'type']
         >>> data["type"]
@@ -137,17 +134,14 @@ def _read_category_dir(category_dir: Path, entity_type: EntityType) -> dict[str,
     of their own — that's reserved for leaves.
 
     Examples:
-        >>> import tempfile
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     cat = Path(d) / "abnormal_lab"
-        ...     cat.mkdir()
-        ...     _ = (cat / "README.md").write_text("Lab tasks")
-        ...     _read_category_dir(cat, "task")
+        >>> tree = {
+        ...     "abnormal_lab/": {"README.md": "Lab tasks"},
+        ...     "empty/": {".gitkeep": ""},
+        ... }
+        >>> with yaml_disk(tree) as d:
+        ...     _read_category_dir(d / "abnormal_lab", "task")
+        ...     _read_category_dir(d / "empty", "task")
         {'type': 'task', 'readme': 'Lab tasks'}
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     cat = Path(d) / "empty"
-        ...     cat.mkdir()
-        ...     _read_category_dir(cat, "task")
         {'type': 'task'}
     """
     data: dict[str, Any] = {"type": entity_type}
@@ -161,11 +155,8 @@ def _walk_ancestors(leaf: Path, root: Path) -> Iterator[Path]:
     """Yield each ancestor directory of ``leaf`` up to (not including) ``root``.
 
     Examples:
-        >>> import tempfile
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     root = Path(d)
-        ...     leaf = root / "a" / "b" / "c"
-        ...     [str(p.relative_to(root)) for p in _walk_ancestors(leaf, root)]
+        >>> with yaml_disk({"a/b/c/": {".gitkeep": ""}}) as root:
+        ...     [str(p.relative_to(root)) for p in _walk_ancestors(root / "a" / "b" / "c", root)]
         ['a/b', 'a']
     """
     parent = leaf.parent
@@ -207,19 +198,17 @@ def _collate_dir_leaves(root: Path, entity_type: Literal["dataset", "model"]) ->
     """Collate a tree where each leaf is a directory containing ``<entity_type>.yaml`` (datasets, models).
 
     Examples:
-        >>> import tempfile
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     root = Path(d)
-        ...     # MIMIC-IV (leaf only — no parent category README)
-        ...     mimic = root / "MIMIC-IV"
-        ...     mimic.mkdir()
-        ...     _ = (mimic / "dataset.yaml").write_text("metadata:\\n  description: foo\\n")
-        ...     _ = (mimic / "README.md").write_text("MIMIC text")
-        ...     # nested MIMIC/III with parent category README
-        ...     leaf = root / "MIMIC" / "III"
-        ...     leaf.mkdir(parents=True)
-        ...     _ = (leaf / "dataset.yaml").write_text("metadata: {description: bar}")
-        ...     _ = (root / "MIMIC" / "README.md").write_text("MIMIC family")
+        >>> tree = {
+        ...     "MIMIC-IV/": {
+        ...         "dataset.yaml": {"metadata": {"description": "foo"}},
+        ...         "README.md": "MIMIC text",
+        ...     },
+        ...     "MIMIC/": {
+        ...         "README.md": "MIMIC family",
+        ...         "III/": {"dataset.yaml": {"metadata": {"description": "bar"}}},
+        ...     },
+        ... }
+        >>> with yaml_disk(tree) as root:
         ...     nodes = _collate_dir_leaves(root, "dataset")
         ...     sorted(nodes.keys())
         ['MIMIC', 'MIMIC-IV', 'MIMIC/III']
@@ -253,16 +242,16 @@ def _collate_task_files(root: Path) -> dict[str, Node]:
     leaf's ``entity`` block. Category nodes come from ancestor directories that have a ``README.md``.
 
     Examples:
-        >>> import tempfile
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     root = Path(d)
-        ...     # mortality/in_icu/first_24h.yaml
-        ...     leaf = root / "mortality" / "in_icu"
-        ...     leaf.mkdir(parents=True)
-        ...     _ = (leaf / "first_24h.yaml").write_text("predicates: {a: b}")
-        ...     # category READMEs
-        ...     _ = (root / "mortality" / "README.md").write_text("Mortality tasks")
-        ...     _ = (root / "mortality" / "in_icu" / "README.md").write_text("ICU mortality")
+        >>> tree = {
+        ...     "mortality/": {
+        ...         "README.md": "Mortality tasks",
+        ...         "in_icu/": {
+        ...             "README.md": "ICU mortality",
+        ...             "first_24h.yaml": {"predicates": {"a": "b"}},
+        ...         },
+        ...     },
+        ... }
+        >>> with yaml_disk(tree) as root:
         ...     nodes = _collate_task_files(root)
         ...     sorted(nodes.keys())
         ['mortality', 'mortality/in_icu', 'mortality/in_icu/first_24h']
@@ -321,30 +310,23 @@ def collate_entities(repo_dir: Path, output_dir: Path, do_overwrite: bool = Fals
         FileExistsError: If an output target exists and ``do_overwrite`` is ``False``.
 
     Examples:
-        >>> import json, tempfile
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     repo = Path(d) / "repo"
-        ...     # Minimal source tree
-        ...     leaf = repo / "src" / "MEDS_DEV" / "datasets" / "MIMIC-IV"
-        ...     leaf.mkdir(parents=True)
-        ...     _ = (leaf / "dataset.yaml").write_text("metadata:\\n  description: foo")
-        ...     task_dir = repo / "src" / "MEDS_DEV" / "tasks" / "mortality" / "in_icu"
-        ...     task_dir.mkdir(parents=True)
-        ...     _ = (task_dir / "first_24h.yaml").write_text("predicates: {x: y}")
-        ...     model_dir = repo / "src" / "MEDS_DEV" / "models" / "random_predictor"
-        ...     model_dir.mkdir(parents=True)
-        ...     _ = (model_dir / "model.yaml").write_text("metadata:\\n  description: rp")
-        ...     out = Path(d) / "out"
-        ...     collate_entities(repo, out, do_overwrite=True)
-        ...     sorted(p.name for p in out.iterdir())
+        >>> tree = {
+        ...     "repo/src/MEDS_DEV/": {
+        ...         "datasets/MIMIC-IV/dataset.yaml": {"metadata": {"description": "foo"}},
+        ...         "tasks/mortality/in_icu/first_24h.yaml": {"predicates": {"x": "y"}},
+        ...         "models/random_predictor/model.yaml": {"metadata": {"description": "rp"}},
+        ...     },
+        ... }
+        >>> with yaml_disk(tree) as d:
+        ...     collate_entities(d / "repo", d / "out", do_overwrite=True)
+        ...     sorted(p.name for p in (d / "out").iterdir())
         ['datasets.json', 'models.json', 'tasks.json']
-        >>> with tempfile.TemporaryDirectory() as d:
-        ...     repo = Path(d) / "repo"
-        ...     repo.mkdir()
-        ...     out = Path(d) / "out"
-        ...     out.mkdir()
-        ...     _ = (out / "datasets.json").write_text("stale")
-        ...     collate_entities(repo, out, do_overwrite=False)
+
+    Existing output files without ``do_overwrite=True`` are an error, as is a missing repo:
+
+        >>> stale = {"repo/.gitkeep": "", "out/datasets.json": "stale"}
+        >>> with yaml_disk(stale) as d:
+        ...     collate_entities(d / "repo", d / "out", do_overwrite=False)
         Traceback (most recent call last):
             ...
         FileExistsError: Output path ... already exists. Pass do_overwrite=True to replace.

--- a/src/MEDS_DEV/web/collate_entities.py
+++ b/src/MEDS_DEV/web/collate_entities.py
@@ -96,25 +96,24 @@ def _read_leaf_dir(leaf_dir: Path, entity_type: EntityType) -> dict[str, Any]:
     ``LEAF_FILES`` go under their mapped keys.
 
     Examples:
-        >>> tree = {
-        ...     "MIMIC-IV/": {
-        ...         "dataset.yaml": {"metadata": {"description": "foo"}},
-        ...         "README.md": "# MIMIC",
-        ...         "requirements.txt": "meds==0.3.3\\n",
-        ...     }
-        ... }
+        >>> tree = '''
+        ... MIMIC-IV/:
+        ...   dataset.yaml: {metadata: {description: foo}}
+        ...   README.md: |
+        ...     # MIMIC
+        ...   requirements.txt: |
+        ...     meds==0.3.3
+        ... '''
         >>> with yaml_disk(tree) as d:
         ...     data = _read_leaf_dir(d / "MIMIC-IV", "dataset")
-        ...     sorted(data.keys())
-        ['entity', 'readme', 'requirements', 'type']
-        >>> data["type"]
-        'dataset'
-        >>> data["entity"]
-        {'metadata': {'description': 'foo'}}
-        >>> data["readme"]
-        '# MIMIC'
-        >>> data["requirements"]
-        ['meds==0.3.3']
+        ...     print("type:        ", data["type"])
+        ...     print("entity:      ", data["entity"])
+        ...     print("readme:      ", repr(data["readme"]))
+        ...     print("requirements:", data["requirements"])
+        type:         dataset
+        entity:       {'metadata': {'description': 'foo'}}
+        readme:       '# MIMIC\\n'
+        requirements: ['meds==0.3.3']
     """
     data: dict[str, Any] = {"type": entity_type}
 
@@ -335,9 +334,27 @@ def collate_entities(repo_dir: Path, output_dir: Path, do_overwrite: bool = Fals
         >>> with yaml_disk(tree) as d:
         ...     collate_entities(d / "repo", d / "out", do_overwrite=True)
         ...     print_directory(d / "out")
+        ...     print("\\ndatasets.json:")
+        ...     print(json.dumps(json.loads((d / "out" / "datasets.json").read_text()), indent=2))
         ├── datasets.json
         ├── models.json
         └── tasks.json
+        <BLANKLINE>
+        datasets.json:
+        {
+          "MIMIC-IV": {
+            "children": [],
+            "data": {
+              "entity": {
+                "metadata": {
+                  "description": "foo"
+                }
+              },
+              "type": "dataset"
+            },
+            "name": "MIMIC-IV"
+          }
+        }
 
     Existing output files without ``do_overwrite=True`` are an error, and so are a non-directory
     repo or a directory at one of the output paths:
@@ -375,24 +392,25 @@ def collate_entities(repo_dir: Path, output_dir: Path, do_overwrite: bool = Fals
         raise NotADirectoryError(f"Repository path {repo_dir!s} is not a directory.")
 
     output_dir.mkdir(parents=True, exist_ok=True)
+    output_names = ("datasets.json", "tasks.json", "models.json")
 
-    targets: dict[str, dict[str, Any]] = {
+    # Validate output paths before doing the actual collation work so we fail fast on a stale
+    # output dir without walking the source tree first.
+    for name in output_names:
+        fp = output_dir / name
+        if not fp.exists():
+            continue
+        if fp.is_dir():
+            raise IsADirectoryError(f"Output path {fp!s} is a directory; refusing to write.")
+        if not do_overwrite:
+            raise FileExistsError(f"Output path {fp!s} already exists. Pass do_overwrite=True to replace.")
+
+    payloads = {
         "datasets.json": collate_datasets(repo_dir),
         "tasks.json": collate_tasks(repo_dir),
         "models.json": collate_models(repo_dir),
     }
-
-    for name in targets:
-        fp = output_dir / name
-        if fp.exists():
-            if fp.is_dir():
-                raise IsADirectoryError(f"Output path {fp!s} is a directory; refusing to write.")
-            if not do_overwrite:
-                raise FileExistsError(
-                    f"Output path {fp!s} already exists. Pass do_overwrite=True to replace."
-                )
-
-    for name, payload in targets.items():
+    for name, payload in payloads.items():
         (output_dir / name).write_text(json.dumps(payload, indent=2, sort_keys=True))
 
 

--- a/src/MEDS_DEV/web/collate_entities.py
+++ b/src/MEDS_DEV/web/collate_entities.py
@@ -198,16 +198,15 @@ def _collate_dir_leaves(root: Path, entity_type: Literal["dataset", "model"]) ->
     """Collate a tree where each leaf is a directory containing ``<entity_type>.yaml`` (datasets, models).
 
     Examples:
-        >>> tree = {
-        ...     "MIMIC-IV/": {
-        ...         "dataset.yaml": {"metadata": {"description": "foo"}},
-        ...         "README.md": "MIMIC text",
-        ...     },
-        ...     "MIMIC/": {
-        ...         "README.md": "MIMIC family",
-        ...         "III/": {"dataset.yaml": {"metadata": {"description": "bar"}}},
-        ...     },
-        ... }
+        >>> tree = '''
+        ... MIMIC-IV/:
+        ...   dataset.yaml: {metadata: {description: foo}}
+        ...   README.md: MIMIC text
+        ... MIMIC/:
+        ...   README.md: MIMIC family
+        ...   III/:
+        ...     dataset.yaml: {metadata: {description: bar}}
+        ... '''
         >>> with yaml_disk(tree) as root:
         ...     nodes = _collate_dir_leaves(root, "dataset")
         ...     sorted(nodes.keys())
@@ -242,15 +241,13 @@ def _collate_task_files(root: Path) -> dict[str, Node]:
     leaf's ``entity`` block. Category nodes come from ancestor directories that have a ``README.md``.
 
     Examples:
-        >>> tree = {
-        ...     "mortality/": {
-        ...         "README.md": "Mortality tasks",
-        ...         "in_icu/": {
-        ...             "README.md": "ICU mortality",
-        ...             "first_24h.yaml": {"predicates": {"a": "b"}},
-        ...         },
-        ...     },
-        ... }
+        >>> tree = '''
+        ... mortality/:
+        ...   README.md: Mortality tasks
+        ...   in_icu/:
+        ...     README.md: ICU mortality
+        ...     first_24h.yaml: {predicates: {a: b}}
+        ... '''
         >>> with yaml_disk(tree) as root:
         ...     nodes = _collate_task_files(root)
         ...     sorted(nodes.keys())
@@ -310,13 +307,21 @@ def collate_entities(repo_dir: Path, output_dir: Path, do_overwrite: bool = Fals
         FileExistsError: If an output target exists and ``do_overwrite`` is ``False``.
 
     Examples:
-        >>> tree = {
-        ...     "repo/src/MEDS_DEV/": {
-        ...         "datasets/MIMIC-IV/dataset.yaml": {"metadata": {"description": "foo"}},
-        ...         "tasks/mortality/in_icu/first_24h.yaml": {"predicates": {"x": "y"}},
-        ...         "models/random_predictor/model.yaml": {"metadata": {"description": "rp"}},
-        ...     },
-        ... }
+        >>> tree = '''
+        ... repo/:
+        ...   src/:
+        ...     MEDS_DEV/:
+        ...       datasets/:
+        ...         MIMIC-IV/:
+        ...           dataset.yaml: {metadata: {description: foo}}
+        ...       tasks/:
+        ...         mortality/:
+        ...           in_icu/:
+        ...             first_24h.yaml: {predicates: {x: y}}
+        ...       models/:
+        ...         random_predictor/:
+        ...           model.yaml: {metadata: {description: rp}}
+        ... '''
         >>> with yaml_disk(tree) as d:
         ...     collate_entities(d / "repo", d / "out", do_overwrite=True)
         ...     sorted(p.name for p in (d / "out").iterdir())

--- a/src/MEDS_DEV/web/collate_entities.py
+++ b/src/MEDS_DEV/web/collate_entities.py
@@ -1,0 +1,405 @@
+"""Collate dataset, task, and model entries into JSON manifests for the MEDS-DEV website.
+
+The website (https://medical-event-data-standard.github.io) fetches three JSON files at runtime from the
+``_web`` orphan branch of this repo:
+
+- ``entities/datasets.json``
+- ``entities/tasks.json``
+- ``entities/models.json``
+
+Each is a flat record keyed by entity name (relative path from ``src/MEDS_DEV/<datasets|tasks|models>/``),
+with values shaped like::
+
+    {
+        "name": "<relative path>",
+        "data": {
+            "type": "dataset" | "task" | "model",
+            "entity": <contents of dataset.yaml / task yaml / model.yaml>,
+            "readme": <README.md text, optional>,
+            "refs": <refs.bib text, optional>,
+            "requirements": [<requirements.txt entries>, optional],
+            "predicates": <predicates.yaml dict, datasets only>,
+        },
+        "children": [<names of nested entities, for category nodes>],
+    }
+
+This module produces those manifests deterministically from the source tree. See ``parse_tree.ts`` and
+``types.ts`` in the website repo for the consumer-side schema.
+"""
+
+import argparse
+import json
+from collections.abc import Iterator
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from omegaconf import OmegaConf
+
+EntityType = Literal["dataset", "task", "model"]
+
+DATASETS_REL_PATH = Path("src/MEDS_DEV/datasets")
+TASKS_REL_PATH = Path("src/MEDS_DEV/tasks")
+MODELS_REL_PATH = Path("src/MEDS_DEV/models")
+
+# Files whose presence in a leaf directory contributes to the ``data`` block.
+# Keyed by file name; value is the JSON key used in the output.
+LEAF_FILES: dict[str, str] = {
+    "README.md": "readme",
+    "refs.bib": "refs",
+    "predicates.yaml": "predicates",
+    "requirements.txt": "requirements",
+}
+
+
+@dataclass
+class Node:
+    name: str
+    data: dict[str, Any] = field(default_factory=dict)
+    children: list[str] = field(default_factory=list)
+
+
+def _read_file(path: Path) -> Any:
+    """Read a single file from a leaf directory, dispatching by extension.
+
+    Examples:
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     p = Path(d) / "predicates.yaml"
+        ...     _ = p.write_text("foo: bar\\n")
+        ...     _read_file(p)
+        {'foo': 'bar'}
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     p = Path(d) / "requirements.txt"
+        ...     _ = p.write_text("numpy==1.21.0\\npandas==2.0.0\\n")
+        ...     _read_file(p)
+        ['numpy==1.21.0', 'pandas==2.0.0']
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     p = Path(d) / "README.md"
+        ...     _ = p.write_text("# Title\\n")
+        ...     _read_file(p)
+        '# Title\\n'
+    """
+    if path.suffix == ".yaml":
+        # ``???`` placeholders (Hydra missing values) are valid in MEDS-DEV task configs and must
+        # survive serialization. ``to_container`` with ``throw_on_missing=False`` preserves them
+        # as the literal string ``"???"``.
+        return OmegaConf.to_container(OmegaConf.load(path), resolve=False, throw_on_missing=False)
+    if path.suffix == ".txt":
+        return [line.strip() for line in path.read_text().splitlines() if line.strip()]
+    return path.read_text()
+
+
+def _read_leaf_dir(leaf_dir: Path, entity_type: EntityType) -> dict[str, Any]:
+    """Read the data block for a directory-based leaf (dataset or model).
+
+    The ``<entity_type>.yaml`` file goes under ``entity``; sibling files matching
+    ``LEAF_FILES`` go under their mapped keys.
+
+    Examples:
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     leaf = Path(d) / "MIMIC-IV"
+        ...     leaf.mkdir()
+        ...     _ = (leaf / "dataset.yaml").write_text("metadata:\\n  description: foo\\n")
+        ...     _ = (leaf / "README.md").write_text("# MIMIC")
+        ...     _ = (leaf / "requirements.txt").write_text("meds==0.3.3\\n")
+        ...     data = _read_leaf_dir(leaf, "dataset")
+        ...     sorted(data.keys())
+        ['entity', 'readme', 'requirements', 'type']
+        >>> data["type"]
+        'dataset'
+        >>> data["entity"]
+        {'metadata': {'description': 'foo'}}
+        >>> data["readme"]
+        '# MIMIC'
+        >>> data["requirements"]
+        ['meds==0.3.3']
+    """
+    data: dict[str, Any] = {"type": entity_type}
+
+    spec_path = leaf_dir / f"{entity_type}.yaml"
+    if spec_path.is_file():
+        data["entity"] = _read_file(spec_path)
+
+    for fname, key in LEAF_FILES.items():
+        sibling = leaf_dir / fname
+        if sibling.is_file():
+            data[key] = _read_file(sibling)
+
+    return data
+
+
+def _read_category_dir(category_dir: Path, entity_type: EntityType) -> dict[str, Any]:
+    """Read the data block for a category directory.
+
+    Categories carry a ``type`` and (optionally) a ``readme``. They never have an ``entity`` block
+    of their own — that's reserved for leaves.
+
+    Examples:
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     cat = Path(d) / "abnormal_lab"
+        ...     cat.mkdir()
+        ...     _ = (cat / "README.md").write_text("Lab tasks")
+        ...     _read_category_dir(cat, "task")
+        {'type': 'task', 'readme': 'Lab tasks'}
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     cat = Path(d) / "empty"
+        ...     cat.mkdir()
+        ...     _read_category_dir(cat, "task")
+        {'type': 'task'}
+    """
+    data: dict[str, Any] = {"type": entity_type}
+    readme = category_dir / "README.md"
+    if readme.is_file():
+        data["readme"] = readme.read_text()
+    return data
+
+
+def _walk_ancestors(leaf: Path, root: Path) -> Iterator[Path]:
+    """Yield each ancestor directory of ``leaf`` up to (not including) ``root``.
+
+    Examples:
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     root = Path(d)
+        ...     leaf = root / "a" / "b" / "c"
+        ...     [str(p.relative_to(root)) for p in _walk_ancestors(leaf, root)]
+        ['a/b', 'a']
+    """
+    parent = leaf.parent
+    while parent != root:
+        yield parent
+        if parent == parent.parent:  # filesystem root reached
+            return
+        parent = parent.parent
+
+
+def _add_category_chain(
+    nodes: dict[str, Node],
+    leaf_path: Path,
+    leaf_name: str,
+    root: Path,
+    entity_type: EntityType,
+) -> None:
+    """Walk up from a leaf, registering category nodes (those with a README) and linking them as parents.
+
+    Categories without a README are skipped silently — the chain "jumps over" them. This matches the prototype
+    behavior and avoids polluting the output with empty intermediate nodes.
+    """
+    child_name = leaf_name
+    for ancestor in _walk_ancestors(leaf_path, root):
+        cat_data = _read_category_dir(ancestor, entity_type)
+        if "readme" not in cat_data:
+            continue
+        cat_name = ancestor.relative_to(root).as_posix()
+        if cat_name not in nodes:
+            nodes[cat_name] = Node(name=cat_name, data=cat_data)
+        if child_name not in nodes[cat_name].children:
+            nodes[cat_name].children.append(child_name)
+        child_name = cat_name
+
+
+def _collate_dir_leaves(root: Path, entity_type: Literal["dataset", "model"]) -> dict[str, Node]:
+    """Collate a tree where each leaf is a directory containing ``<entity_type>.yaml`` (datasets, models).
+
+    Examples:
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     root = Path(d)
+        ...     # MIMIC-IV (leaf only — no parent category README)
+        ...     mimic = root / "MIMIC-IV"
+        ...     mimic.mkdir()
+        ...     _ = (mimic / "dataset.yaml").write_text("metadata:\\n  description: foo\\n")
+        ...     _ = (mimic / "README.md").write_text("MIMIC text")
+        ...     # nested MIMIC/III with parent category README
+        ...     leaf = root / "MIMIC" / "III"
+        ...     leaf.mkdir(parents=True)
+        ...     _ = (leaf / "dataset.yaml").write_text("metadata: {description: bar}")
+        ...     _ = (root / "MIMIC" / "README.md").write_text("MIMIC family")
+        ...     nodes = _collate_dir_leaves(root, "dataset")
+        ...     sorted(nodes.keys())
+        ['MIMIC', 'MIMIC-IV', 'MIMIC/III']
+        >>> nodes["MIMIC/III"].data["entity"]
+        {'metadata': {'description': 'bar'}}
+        >>> nodes["MIMIC"].children
+        ['MIMIC/III']
+        >>> nodes["MIMIC"].data["readme"]
+        'MIMIC family'
+    """
+    nodes: dict[str, Node] = {}
+    spec_name = f"{entity_type}.yaml"
+
+    leaves = sorted(root.rglob(spec_name))
+    for spec_path in leaves:
+        leaf_dir = spec_path.parent
+        name = leaf_dir.relative_to(root).as_posix()
+        nodes[name] = Node(
+            name=name,
+            data=_read_leaf_dir(leaf_dir, entity_type),
+        )
+        _add_category_chain(nodes, leaf_dir, name, root, entity_type)
+
+    return nodes
+
+
+def _collate_task_files(root: Path) -> dict[str, Node]:
+    """Collate the task tree where each leaf is a ``*.yaml`` file (not a directory).
+
+    The task name is the relative path with the ``.yaml`` suffix stripped; the file's contents become the
+    leaf's ``entity`` block. Category nodes come from ancestor directories that have a ``README.md``.
+
+    Examples:
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     root = Path(d)
+        ...     # mortality/in_icu/first_24h.yaml
+        ...     leaf = root / "mortality" / "in_icu"
+        ...     leaf.mkdir(parents=True)
+        ...     _ = (leaf / "first_24h.yaml").write_text("predicates: {a: b}")
+        ...     # category READMEs
+        ...     _ = (root / "mortality" / "README.md").write_text("Mortality tasks")
+        ...     _ = (root / "mortality" / "in_icu" / "README.md").write_text("ICU mortality")
+        ...     nodes = _collate_task_files(root)
+        ...     sorted(nodes.keys())
+        ['mortality', 'mortality/in_icu', 'mortality/in_icu/first_24h']
+        >>> nodes["mortality/in_icu/first_24h"].data["entity"]
+        {'predicates': {'a': 'b'}}
+        >>> nodes["mortality/in_icu"].children
+        ['mortality/in_icu/first_24h']
+        >>> nodes["mortality"].children
+        ['mortality/in_icu']
+    """
+    nodes: dict[str, Node] = {}
+
+    leaves = sorted(root.rglob("*.yaml"))
+    for yaml_path in leaves:
+        name = yaml_path.relative_to(root).with_suffix("").as_posix()
+        nodes[name] = Node(
+            name=name,
+            data={"type": "task", "entity": _read_file(yaml_path)},
+        )
+        _add_category_chain(nodes, yaml_path, name, root, "task")
+
+    return nodes
+
+
+def collate_datasets(repo_dir: Path) -> dict[str, dict[str, Any]]:
+    """Collate dataset entries rooted at ``repo_dir / src / MEDS_DEV / datasets``."""
+    nodes = _collate_dir_leaves(repo_dir / DATASETS_REL_PATH, "dataset")
+    return {k: asdict(v) for k, v in nodes.items()}
+
+
+def collate_tasks(repo_dir: Path) -> dict[str, dict[str, Any]]:
+    """Collate task entries rooted at ``repo_dir / src / MEDS_DEV / tasks``."""
+    nodes = _collate_task_files(repo_dir / TASKS_REL_PATH)
+    return {k: asdict(v) for k, v in nodes.items()}
+
+
+def collate_models(repo_dir: Path) -> dict[str, dict[str, Any]]:
+    """Collate model entries rooted at ``repo_dir / src / MEDS_DEV / models``."""
+    nodes = _collate_dir_leaves(repo_dir / MODELS_REL_PATH, "model")
+    return {k: asdict(v) for k, v in nodes.items()}
+
+
+def collate_entities(repo_dir: Path, output_dir: Path, do_overwrite: bool = False) -> None:
+    """Write ``datasets.json``, ``tasks.json``, ``models.json`` to ``output_dir``.
+
+    Args:
+        repo_dir: Path to the MEDS-DEV repository (the directory containing ``src/MEDS_DEV/``).
+        output_dir: Directory where the manifests will be written.
+        do_overwrite: If ``False`` (default) and any output file already exists, raise.
+            If ``True``, overwrite.
+
+    Raises:
+        FileNotFoundError: If ``repo_dir`` does not exist.
+        NotADirectoryError: If ``repo_dir`` is not a directory.
+        IsADirectoryError: If an output target exists as a directory.
+        FileExistsError: If an output target exists and ``do_overwrite`` is ``False``.
+
+    Examples:
+        >>> import json, tempfile
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     repo = Path(d) / "repo"
+        ...     # Minimal source tree
+        ...     leaf = repo / "src" / "MEDS_DEV" / "datasets" / "MIMIC-IV"
+        ...     leaf.mkdir(parents=True)
+        ...     _ = (leaf / "dataset.yaml").write_text("metadata:\\n  description: foo")
+        ...     task_dir = repo / "src" / "MEDS_DEV" / "tasks" / "mortality" / "in_icu"
+        ...     task_dir.mkdir(parents=True)
+        ...     _ = (task_dir / "first_24h.yaml").write_text("predicates: {x: y}")
+        ...     model_dir = repo / "src" / "MEDS_DEV" / "models" / "random_predictor"
+        ...     model_dir.mkdir(parents=True)
+        ...     _ = (model_dir / "model.yaml").write_text("metadata:\\n  description: rp")
+        ...     out = Path(d) / "out"
+        ...     collate_entities(repo, out, do_overwrite=True)
+        ...     sorted(p.name for p in out.iterdir())
+        ['datasets.json', 'models.json', 'tasks.json']
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     repo = Path(d) / "repo"
+        ...     repo.mkdir()
+        ...     out = Path(d) / "out"
+        ...     out.mkdir()
+        ...     _ = (out / "datasets.json").write_text("stale")
+        ...     collate_entities(repo, out, do_overwrite=False)
+        Traceback (most recent call last):
+            ...
+        FileExistsError: Output path ... already exists. Pass do_overwrite=True to replace.
+        >>> collate_entities(Path("/nonexistent_path_xyz"), Path("/tmp"))
+        Traceback (most recent call last):
+            ...
+        FileNotFoundError: Repository directory /nonexistent_path_xyz does not exist.
+    """
+    if not repo_dir.exists():
+        raise FileNotFoundError(f"Repository directory {repo_dir!s} does not exist.")
+    if not repo_dir.is_dir():
+        raise NotADirectoryError(f"Repository path {repo_dir!s} is not a directory.")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    targets: dict[str, dict[str, Any]] = {
+        "datasets.json": collate_datasets(repo_dir),
+        "tasks.json": collate_tasks(repo_dir),
+        "models.json": collate_models(repo_dir),
+    }
+
+    for name in targets:
+        fp = output_dir / name
+        if fp.exists():
+            if fp.is_dir():
+                raise IsADirectoryError(f"Output path {fp!s} is a directory; refusing to write.")
+            if not do_overwrite:
+                raise FileExistsError(
+                    f"Output path {fp!s} already exists. Pass do_overwrite=True to replace."
+                )
+
+    for name, payload in targets.items():
+        (output_dir / name).write_text(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Collate MEDS-DEV entity manifests for the website.")
+    parser.add_argument(
+        "--repo_dir",
+        type=Path,
+        default=Path.cwd(),
+        help="Path to the MEDS-DEV repository (default: current directory).",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=Path,
+        required=True,
+        help="Directory to write datasets.json, tasks.json, models.json into.",
+    )
+    parser.add_argument(
+        "--do_overwrite",
+        action="store_true",
+        help="Overwrite existing manifest files instead of raising.",
+    )
+    args = parser.parse_args()
+    collate_entities(args.repo_dir, args.output_dir, args.do_overwrite)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/MEDS_DEV/web/collate_entities.py
+++ b/src/MEDS_DEV/web/collate_entities.py
@@ -63,18 +63,21 @@ def _read_file(path: Path) -> Any:
     """Read a single file from a leaf directory, dispatching by extension.
 
     Examples:
-        >>> tree = {
-        ...     "predicates.yaml": {"foo": "bar"},
-        ...     "requirements.txt": "numpy==1.21.0\\npandas==2.0.0\\n",
-        ...     "README.md": "# Title\\n",
-        ... }
+        >>> tree = '''
+        ... predicates.yaml: {foo: bar}
+        ... requirements.txt: |
+        ...   numpy==1.21.0
+        ...   pandas==2.0.0
+        ... README.md: |
+        ...   # Title
+        ... '''
         >>> with yaml_disk(tree) as d:
-        ...     _read_file(d / "predicates.yaml")
-        ...     _read_file(d / "requirements.txt")
-        ...     _read_file(d / "README.md")
-        {'foo': 'bar'}
-        ['numpy==1.21.0', 'pandas==2.0.0']
-        '# Title\\n'
+        ...     print("predicates:  ", _read_file(d / "predicates.yaml"))
+        ...     print("requirements:", _read_file(d / "requirements.txt"))
+        ...     print("readme:      ", repr(_read_file(d / "README.md")))
+        predicates:   {'foo': 'bar'}
+        requirements: ['numpy==1.21.0', 'pandas==2.0.0']
+        readme:       '# Title\\n'
     """
     if path.suffix == ".yaml":
         # ``???`` placeholders (Hydra missing values) are valid in MEDS-DEV task configs and must
@@ -158,6 +161,13 @@ def _walk_ancestors(leaf: Path, root: Path) -> Iterator[Path]:
         >>> with yaml_disk({"a/b/c/": {".gitkeep": ""}}) as root:
         ...     [str(p.relative_to(root)) for p in _walk_ancestors(root / "a" / "b" / "c", root)]
         ['a/b', 'a']
+
+        Defensive: if ``leaf`` isn't actually under ``root``, the walk stops at the filesystem
+        root rather than looping forever:
+
+        >>> ancestors = list(_walk_ancestors(Path("/x/y/z"), Path("/totally/different")))
+        >>> ancestors[-1]
+        PosixPath('/')
     """
     parent = leaf.parent
     while parent != root:
@@ -324,10 +334,13 @@ def collate_entities(repo_dir: Path, output_dir: Path, do_overwrite: bool = Fals
         ... '''
         >>> with yaml_disk(tree) as d:
         ...     collate_entities(d / "repo", d / "out", do_overwrite=True)
-        ...     sorted(p.name for p in (d / "out").iterdir())
-        ['datasets.json', 'models.json', 'tasks.json']
+        ...     print_directory(d / "out")
+        ├── datasets.json
+        ├── models.json
+        └── tasks.json
 
-    Existing output files without ``do_overwrite=True`` are an error, as is a missing repo:
+    Existing output files without ``do_overwrite=True`` are an error, and so are a non-directory
+    repo or a directory at one of the output paths:
 
         >>> stale = {"repo/.gitkeep": "", "out/datasets.json": "stale"}
         >>> with yaml_disk(stale) as d:
@@ -339,6 +352,22 @@ def collate_entities(repo_dir: Path, output_dir: Path, do_overwrite: bool = Fals
         Traceback (most recent call last):
             ...
         FileNotFoundError: Repository directory /nonexistent_path_xyz does not exist.
+        >>> with yaml_disk({"a.txt": "scalar"}) as d:
+        ...     collate_entities(d / "a.txt", d / "out", do_overwrite=True)
+        Traceback (most recent call last):
+            ...
+        NotADirectoryError: Repository path ... is not a directory.
+        >>> tree = '''
+        ... repo/src/MEDS_DEV/datasets/MIMIC-IV/dataset.yaml: {metadata: {description: foo}}
+        ... out/:
+        ...   datasets.json/:
+        ...     .gitkeep: ""
+        ... '''
+        >>> with yaml_disk(tree) as d:
+        ...     collate_entities(d / "repo", d / "out", do_overwrite=True)
+        Traceback (most recent call last):
+            ...
+        IsADirectoryError: Output path ... is a directory; refusing to write.
     """
     if not repo_dir.exists():
         raise FileNotFoundError(f"Repository directory {repo_dir!s} does not exist.")

--- a/src/MEDS_DEV/web/collate_entities.py
+++ b/src/MEDS_DEV/web/collate_entities.py
@@ -171,7 +171,7 @@ def _walk_ancestors(leaf: Path, root: Path) -> Iterator[Path]:
     parent = leaf.parent
     while parent != root:
         yield parent
-        if parent == parent.parent:  # filesystem root reached
+        if parent == parent.parent:  # pragma: no cover  # filesystem root reached
             return
         parent = parent.parent
 
@@ -401,5 +401,5 @@ def main() -> None:
     collate_entities(args.repo_dir, args.output_dir, args.do_overwrite)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/src/MEDS_DEV/web/collate_entities.py
+++ b/src/MEDS_DEV/web/collate_entities.py
@@ -333,13 +333,14 @@ def collate_entities(repo_dir: Path, output_dir: Path, do_overwrite: bool = Fals
         ... '''
         >>> with yaml_disk(tree) as d:
         ...     collate_entities(d / "repo", d / "out", do_overwrite=True)
+        ...     print("Directory:")
         ...     print_directory(d / "out")
-        ...     print("\\ndatasets.json:")
+        ...     print("datasets.json:")
         ...     print(json.dumps(json.loads((d / "out" / "datasets.json").read_text()), indent=2))
+        Directory:
         ├── datasets.json
         ├── models.json
         └── tasks.json
-        <BLANKLINE>
         datasets.json:
         {
           "MIMIC-IV": {

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -14,7 +14,7 @@ import pytest
 
 from MEDS_DEV.web.aggregate_results import aggregate_results
 from MEDS_DEV.web.aggregate_results import main as aggregate_main
-from MEDS_DEV.web.collate_entities import collate_entities
+from MEDS_DEV.web.collate_entities import _walk_ancestors, collate_entities
 from MEDS_DEV.web.collate_entities import main as collate_main
 
 # ---------------------------------------------------------------------------
@@ -76,6 +76,26 @@ def test_collate_entities_rejects_directory_in_output_slot(tmp_path: Path) -> No
 
     with pytest.raises(IsADirectoryError, match="is a directory"):
         collate_entities(repo, out, do_overwrite=True)
+
+
+# ---------------------------------------------------------------------------
+# _walk_ancestors: filesystem-root defensive return
+# ---------------------------------------------------------------------------
+
+
+def test_walk_ancestors_terminates_when_leaf_is_not_under_root() -> None:
+    """If ``leaf`` isn't actually under ``root``, the walk must stop at the filesystem root rather than loop
+    forever.
+
+    Triggers the ``parent == parent.parent`` guard.
+    """
+    leaf = Path("/some/leaf/path")
+    bogus_root = Path("/totally/different/tree")
+    ancestors = list(_walk_ancestors(leaf, bogus_root))
+    # The yielded sequence ends at "/" once the guard fires.
+    assert ancestors[-1] == Path("/")
+    # And nothing under bogus_root is in the result.
+    assert not any(bogus_root in a.parents or a == bogus_root for a in ancestors)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,52 +1,53 @@
 """Coverage for ``MEDS_DEV.web`` paths that aren't exercised by the in-module doctests.
 
-The doctests in the web module cover the happy paths and the most common error paths. This file
-fills in the rest: parse-error / error-threshold paths in ``aggregate_results``, the directory-type
-errors in ``collate_entities``, and the ``main`` CLI entry points (which are tedious to exercise
-from doctests but trivial to call with a monkeypatched ``sys.argv``).
+The doctests cover the happy paths and most of the error paths via :func:`yaml_to_disk.yaml_disk`.
+This file fills in the rest: parse-error / error-threshold paths in ``aggregate_results``, the
+directory-type errors in ``collate_entities``, and end-to-end CLI invocations via subprocess (so we
+exercise the actual installed entry points, not just the Python ``main`` function).
 """
 
 import json
-import sys
+import subprocess
 from pathlib import Path
 
 import pytest
+from yaml_to_disk import yaml_disk
 
 from MEDS_DEV.web.aggregate_results import aggregate_results
-from MEDS_DEV.web.aggregate_results import main as aggregate_main
 from MEDS_DEV.web.collate_entities import _walk_ancestors, collate_entities
-from MEDS_DEV.web.collate_entities import main as collate_main
 
 # ---------------------------------------------------------------------------
 # aggregate_results: error paths
 # ---------------------------------------------------------------------------
 
 
-def test_aggregate_results_logs_and_skips_unparseable_blob(tmp_path: Path, caplog) -> None:
+def test_aggregate_results_logs_and_skips_unparseable_blob(caplog) -> None:
     """A single malformed result.json is logged but doesn't abort aggregation."""
-    (tmp_path / "1").mkdir()
-    (tmp_path / "1" / "result.json").write_text('{"valid": "json"}')
-    (tmp_path / "2").mkdir()
-    (tmp_path / "2" / "result.json").write_text("{not valid json")
-
-    out = tmp_path / "all_results.json"
-    with caplog.at_level("WARNING"):
-        agg = aggregate_results(tmp_path, out)
+    # yaml_disk's JSONFile validates+serializes dicts before writing, so it can't write a malformed
+    # blob directly. Set up the directory structure with yaml_disk, then overwrite the malformed
+    # entry as raw text.
+    tree = {
+        "1": {"result.json": {"valid": "json"}},
+        "2": {"result.json": {"placeholder": True}},
+    }
+    with yaml_disk(tree) as d:
+        (d / "2" / "result.json").write_text("{not valid json")
+        with caplog.at_level("WARNING"):
+            agg = aggregate_results(d, d / "all_results.json")
 
     assert "1" in agg, "valid blob should be aggregated"
     assert "2" not in agg, "malformed blob should be skipped"
     assert any("Failed to read" in r.message for r in caplog.records)
 
 
-def test_aggregate_results_aborts_when_error_threshold_exceeded(tmp_path: Path) -> None:
+def test_aggregate_results_aborts_when_error_threshold_exceeded() -> None:
     """If parse errors exceed ``error_threshold``, aggregation raises."""
-    for i in range(5):
-        (tmp_path / str(i)).mkdir()
-        (tmp_path / str(i) / "result.json").write_text("{not valid json")
-
-    out = tmp_path / "all_results.json"
-    with pytest.raises(ValueError, match="Too many parse errors"):
-        aggregate_results(tmp_path, out, error_threshold=2)
+    tree = {str(i): {"result.json": {"placeholder": True}} for i in range(5)}
+    with yaml_disk(tree) as d:
+        for i in range(5):
+            (d / str(i) / "result.json").write_text("{not valid json")
+        with pytest.raises(ValueError, match="Too many parse errors"):
+            aggregate_results(d, d / "all_results.json", error_threshold=2)
 
 
 # ---------------------------------------------------------------------------
@@ -54,28 +55,24 @@ def test_aggregate_results_aborts_when_error_threshold_exceeded(tmp_path: Path) 
 # ---------------------------------------------------------------------------
 
 
-def test_collate_entities_rejects_non_directory_repo(tmp_path: Path) -> None:
+def test_collate_entities_rejects_non_directory_repo() -> None:
     """Passing a file path as ``repo_dir`` raises ``NotADirectoryError``."""
-    file_as_repo = tmp_path / "not_a_dir"
-    file_as_repo.write_text("just a file")
-    with pytest.raises(NotADirectoryError, match="not a directory"):
-        collate_entities(file_as_repo, tmp_path / "out", do_overwrite=True)
+    with (
+        yaml_disk({"not_a_dir.txt": "just a file"}) as d,
+        pytest.raises(NotADirectoryError, match="not a directory"),
+    ):
+        collate_entities(d / "not_a_dir.txt", d / "out", do_overwrite=True)
 
 
-def test_collate_entities_rejects_directory_in_output_slot(tmp_path: Path) -> None:
+def test_collate_entities_rejects_directory_in_output_slot() -> None:
     """If a target output path exists as a directory, raise even with do_overwrite=True."""
-    repo = tmp_path / "repo"
-    (repo / "src" / "MEDS_DEV" / "datasets" / "MIMIC-IV").mkdir(parents=True)
-    (repo / "src" / "MEDS_DEV" / "datasets" / "MIMIC-IV" / "dataset.yaml").write_text(
-        "metadata:\n  description: foo\n"
-    )
-
-    out = tmp_path / "out"
-    out.mkdir()
-    (out / "datasets.json").mkdir()  # collide with the file the collator wants to write
-
-    with pytest.raises(IsADirectoryError, match="is a directory"):
-        collate_entities(repo, out, do_overwrite=True)
+    tree = {
+        "repo/src/MEDS_DEV/datasets/MIMIC-IV/dataset.yaml": {"metadata": {"description": "foo"}},
+        # An existing directory at the spot the collator wants to write datasets.json.
+        "out/datasets.json/": {".gitkeep": ""},
+    }
+    with yaml_disk(tree) as d, pytest.raises(IsADirectoryError, match="is a directory"):
+        collate_entities(d / "repo", d / "out", do_overwrite=True)
 
 
 # ---------------------------------------------------------------------------
@@ -89,71 +86,65 @@ def test_walk_ancestors_terminates_when_leaf_is_not_under_root() -> None:
 
     Triggers the ``parent == parent.parent`` guard.
     """
-    leaf = Path("/some/leaf/path")
-    bogus_root = Path("/totally/different/tree")
-    ancestors = list(_walk_ancestors(leaf, bogus_root))
+    ancestors = list(_walk_ancestors(Path("/some/leaf/path"), Path("/totally/different/tree")))
     # The yielded sequence ends at "/" once the guard fires.
     assert ancestors[-1] == Path("/")
-    # And nothing under bogus_root is in the result.
+    # And nothing under the bogus root is in the result.
+    bogus_root = Path("/totally/different/tree")
     assert not any(bogus_root in a.parents or a == bogus_root for a in ancestors)
 
 
 # ---------------------------------------------------------------------------
-# CLI entry points
+# CLI entry points (invoked as actual subprocesses against the installed package)
 # ---------------------------------------------------------------------------
 
 
-def test_collate_main_cli(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_collate_entities_cli() -> None:
     """``meds-dev-collate-entities`` writes the three manifests to the output directory."""
-    repo = tmp_path / "repo"
-    (repo / "src" / "MEDS_DEV" / "datasets" / "MIMIC-IV").mkdir(parents=True)
-    (repo / "src" / "MEDS_DEV" / "datasets" / "MIMIC-IV" / "dataset.yaml").write_text(
-        "metadata:\n  description: foo\n"
-    )
-    (repo / "src" / "MEDS_DEV" / "tasks" / "mortality").mkdir(parents=True)
-    (repo / "src" / "MEDS_DEV" / "tasks" / "mortality" / "first_24h.yaml").write_text("predicates: {a: b}\n")
-    (repo / "src" / "MEDS_DEV" / "models" / "rp").mkdir(parents=True)
-    (repo / "src" / "MEDS_DEV" / "models" / "rp" / "model.yaml").write_text("metadata:\n  description: rp\n")
-
-    out = tmp_path / "out"
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "meds-dev-collate-entities",
-            "--repo_dir",
-            str(repo),
-            "--output_dir",
-            str(out),
-            "--do_overwrite",
-        ],
-    )
-    collate_main()
-
-    assert {p.name for p in out.iterdir()} == {"datasets.json", "tasks.json", "models.json"}
-    datasets = json.loads((out / "datasets.json").read_text())
-    assert "MIMIC-IV" in datasets
+    tree = {
+        "repo/src/MEDS_DEV/": {
+            "datasets/MIMIC-IV/dataset.yaml": {"metadata": {"description": "foo"}},
+            "tasks/mortality/first_24h.yaml": {"predicates": {"a": "b"}},
+            "models/rp/model.yaml": {"metadata": {"description": "rp"}},
+        }
+    }
+    with yaml_disk(tree) as d:
+        out = d / "out"
+        result = subprocess.run(
+            [
+                "meds-dev-collate-entities",
+                "--repo_dir",
+                str(d / "repo"),
+                "--output_dir",
+                str(out),
+                "--do_overwrite",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert {p.name for p in out.iterdir()} == {"datasets.json", "tasks.json", "models.json"}
+        datasets = json.loads((out / "datasets.json").read_text())
+        assert "MIMIC-IV" in datasets
 
 
-def test_aggregate_main_cli(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_aggregate_results_cli() -> None:
     """``meds-dev-aggregate-results`` writes a populated all_results.json."""
-    in_dir = tmp_path / "_results"
-    in_dir.mkdir()
-    (in_dir / "42").mkdir()
-    (in_dir / "42" / "result.json").write_text('{"value": "from-cli"}')
-
-    out = tmp_path / "all_results.json"
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "meds-dev-aggregate-results",
-            "--input_dir",
-            str(in_dir),
-            "--output_path",
-            str(out),
-        ],
-    )
-    aggregate_main()
-
-    assert json.loads(out.read_text()) == {"42": {"value": "from-cli"}}
+    tree = {"_results/42/result.json": {"value": "from-cli"}}
+    with yaml_disk(tree) as d:
+        out = d / "all_results.json"
+        result = subprocess.run(
+            [
+                "meds-dev-aggregate-results",
+                "--input_dir",
+                str(d / "_results"),
+                "--output_path",
+                str(out),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert json.loads(out.read_text()) == {"42": {"value": "from-cli"}}

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,82 +1,14 @@
-"""Behavioral tests for ``MEDS_DEV.web`` that don't fit cleanly as doctests.
+"""End-to-end CLI tests for ``MEDS_DEV.web``.
 
-The doctests in ``aggregate_results.py`` and ``collate_entities.py`` cover the happy paths and
-file-system error paths (``yaml_disk`` makes those concise). The tests below are the ones whose
-assertions don't fit comfortably in a doctest:
-
-- Logger assertions (``caplog``) for the parse-error / skip / mismatch paths.
-- End-to-end CLI invocations through ``subprocess.run`` against the installed entry points.
+The doctests in ``aggregate_results.py`` and ``collate_entities.py`` cover happy paths, error paths,
+and the log-output contract (via the ``capture_log_to_stdout`` helper). This file is just the
+subprocess-based CLI tests, which can't live in doctests without bloating them with shell setup.
 """
 
 import json
 import subprocess
 
 from yaml_to_disk import yaml_disk
-
-from MEDS_DEV.web.aggregate_results import aggregate_results
-
-
-def test_aggregate_results_logs_and_skips_unparseable_blob(caplog) -> None:
-    """A single malformed result.json is logged but doesn't abort aggregation."""
-    # yaml_disk's JSONFile validates+serializes dicts before writing, so it can't write a malformed
-    # blob directly. Set up the directory structure with yaml_disk, then overwrite the malformed
-    # entry as raw text.
-    tree = {
-        "1": {"result.json": {"valid": "json"}},
-        "2": {"result.json": {"placeholder": True}},
-    }
-    with yaml_disk(tree) as d:
-        (d / "2" / "result.json").write_text("{not valid json")
-        out = d / "all_results.json"
-        with caplog.at_level("WARNING"):
-            aggregate_results(d, out)
-        agg = json.loads(out.read_text())
-
-    assert "1" in agg, "valid blob should be aggregated"
-    assert "2" not in agg, "malformed blob should be skipped"
-    assert any("Failed to read" in r.message for r in caplog.records)
-
-
-def test_aggregate_results_skip_logs_when_content_matches(caplog) -> None:
-    """When an existing aggregated entry matches the on-disk result.json, log info-level skip (no warning, no
-    work)."""
-    with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
-        out = d / "all_results.json"
-        aggregate_results(d, out)  # writes v1
-        with caplog.at_level("INFO"):
-            aggregate_results(d, out)  # second call: same data on disk
-        agg = json.loads(out.read_text())
-    assert agg["1"] == {"result": "v1"}
-    skip_logs = [r for r in caplog.records if "already aggregated" in r.message]
-    assert skip_logs, "expected an info-level skip log"
-    assert not any("Content mismatch" in r.message for r in caplog.records)
-
-
-def test_aggregate_results_warns_on_content_mismatch(caplog) -> None:
-    """When an existing aggregated entry differs from the on-disk result.json, log a loud warning and keep the
-    existing entry (do not silently overwrite)."""
-    with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
-        out = d / "all_results.json"
-        # First aggregation: writes v1 to the output.
-        aggregate_results(d, out)
-        # Mutate the on-disk result.json so it no longer matches the aggregated entry.
-        (d / "1" / "result.json").write_text('{"result": "v2"}')
-
-        with caplog.at_level("WARNING"):
-            aggregate_results(d, out)
-        agg = json.loads(out.read_text())
-
-    # Existing aggregated entry is kept; on-disk drift does not propagate.
-    assert agg["1"] == {"result": "v1"}
-    # ...but a clear warning is emitted naming the affected issue.
-    mismatch_warnings = [r for r in caplog.records if "Content mismatch" in r.message]
-    assert mismatch_warnings, "expected a content-mismatch warning"
-    assert "issue 1" in mismatch_warnings[0].message
-
-
-# ---------------------------------------------------------------------------
-# CLI entry points (invoked as actual subprocesses against the installed package)
-# ---------------------------------------------------------------------------
 
 
 def test_collate_entities_cli() -> None:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -50,6 +50,41 @@ def test_aggregate_results_aborts_when_error_threshold_exceeded() -> None:
             aggregate_results(d, d / "all_results.json", error_threshold=2)
 
 
+def test_aggregate_results_skip_logs_when_content_matches(caplog) -> None:
+    """When an existing aggregated entry matches the on-disk result.json, log info-level skip (no warning, no
+    work)."""
+    with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
+        out = d / "all_results.json"
+        _ = aggregate_results(d, out)  # writes v1
+        with caplog.at_level("INFO"):
+            agg = aggregate_results(d, out)  # second call: same data on disk
+    assert agg["1"] == {"result": "v1"}
+    skip_logs = [r for r in caplog.records if "already aggregated" in r.message]
+    assert skip_logs, "expected an info-level skip log"
+    assert not any("Content mismatch" in r.message for r in caplog.records)
+
+
+def test_aggregate_results_warns_on_content_mismatch(caplog) -> None:
+    """When an existing aggregated entry differs from the on-disk result.json, log a loud warning and keep the
+    existing entry (do not silently overwrite)."""
+    with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
+        out = d / "all_results.json"
+        # First aggregation: writes v1 to the output.
+        _ = aggregate_results(d, out)
+        # Mutate the on-disk result.json so it no longer matches the aggregated entry.
+        (d / "1" / "result.json").write_text('{"result": "v2"}')
+
+        with caplog.at_level("WARNING"):
+            agg = aggregate_results(d, out)
+
+    # Existing aggregated entry is kept; on-disk drift does not propagate.
+    assert agg["1"] == {"result": "v1"}
+    # ...but a clear warning is emitted naming the affected issue.
+    mismatch_warnings = [r for r in caplog.records if "Content mismatch" in r.message]
+    assert mismatch_warnings, "expected a content-mismatch warning"
+    assert "issue 1" in mismatch_warnings[0].message
+
+
 # ---------------------------------------------------------------------------
 # collate_entities: directory-type errors
 # ---------------------------------------------------------------------------

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,24 +1,19 @@
-"""Coverage for ``MEDS_DEV.web`` paths that aren't exercised by the in-module doctests.
+"""Behavioral tests for ``MEDS_DEV.web`` that don't fit cleanly as doctests.
 
-The doctests cover the happy paths and most of the error paths via :func:`yaml_to_disk.yaml_disk`.
-This file fills in the rest: parse-error / error-threshold paths in ``aggregate_results``, the
-directory-type errors in ``collate_entities``, and end-to-end CLI invocations via subprocess (so we
-exercise the actual installed entry points, not just the Python ``main`` function).
+The doctests in ``aggregate_results.py`` and ``collate_entities.py`` cover the happy paths and
+file-system error paths (``yaml_disk`` makes those concise). The tests below are the ones whose
+assertions don't fit comfortably in a doctest:
+
+- Logger assertions (``caplog``) for the parse-error / skip / mismatch paths.
+- End-to-end CLI invocations through ``subprocess.run`` against the installed entry points.
 """
 
 import json
 import subprocess
-from pathlib import Path
 
-import pytest
 from yaml_to_disk import yaml_disk
 
 from MEDS_DEV.web.aggregate_results import aggregate_results
-from MEDS_DEV.web.collate_entities import _walk_ancestors, collate_entities
-
-# ---------------------------------------------------------------------------
-# aggregate_results: error paths
-# ---------------------------------------------------------------------------
 
 
 def test_aggregate_results_logs_and_skips_unparseable_blob(caplog) -> None:
@@ -32,22 +27,14 @@ def test_aggregate_results_logs_and_skips_unparseable_blob(caplog) -> None:
     }
     with yaml_disk(tree) as d:
         (d / "2" / "result.json").write_text("{not valid json")
+        out = d / "all_results.json"
         with caplog.at_level("WARNING"):
-            agg = aggregate_results(d, d / "all_results.json")
+            aggregate_results(d, out)
+        agg = json.loads(out.read_text())
 
     assert "1" in agg, "valid blob should be aggregated"
     assert "2" not in agg, "malformed blob should be skipped"
     assert any("Failed to read" in r.message for r in caplog.records)
-
-
-def test_aggregate_results_aborts_when_error_threshold_exceeded() -> None:
-    """If parse errors exceed ``error_threshold``, aggregation raises."""
-    tree = {str(i): {"result.json": {"placeholder": True}} for i in range(5)}
-    with yaml_disk(tree) as d:
-        for i in range(5):
-            (d / str(i) / "result.json").write_text("{not valid json")
-        with pytest.raises(ValueError, match="Too many parse errors"):
-            aggregate_results(d, d / "all_results.json", error_threshold=2)
 
 
 def test_aggregate_results_skip_logs_when_content_matches(caplog) -> None:
@@ -55,9 +42,10 @@ def test_aggregate_results_skip_logs_when_content_matches(caplog) -> None:
     work)."""
     with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
         out = d / "all_results.json"
-        _ = aggregate_results(d, out)  # writes v1
+        aggregate_results(d, out)  # writes v1
         with caplog.at_level("INFO"):
-            agg = aggregate_results(d, out)  # second call: same data on disk
+            aggregate_results(d, out)  # second call: same data on disk
+        agg = json.loads(out.read_text())
     assert agg["1"] == {"result": "v1"}
     skip_logs = [r for r in caplog.records if "already aggregated" in r.message]
     assert skip_logs, "expected an info-level skip log"
@@ -70,12 +58,13 @@ def test_aggregate_results_warns_on_content_mismatch(caplog) -> None:
     with yaml_disk({"1": {"result.json": {"result": "v1"}}}) as d:
         out = d / "all_results.json"
         # First aggregation: writes v1 to the output.
-        _ = aggregate_results(d, out)
+        aggregate_results(d, out)
         # Mutate the on-disk result.json so it no longer matches the aggregated entry.
         (d / "1" / "result.json").write_text('{"result": "v2"}')
 
         with caplog.at_level("WARNING"):
-            agg = aggregate_results(d, out)
+            aggregate_results(d, out)
+        agg = json.loads(out.read_text())
 
     # Existing aggregated entry is kept; on-disk drift does not propagate.
     assert agg["1"] == {"result": "v1"}
@@ -83,50 +72,6 @@ def test_aggregate_results_warns_on_content_mismatch(caplog) -> None:
     mismatch_warnings = [r for r in caplog.records if "Content mismatch" in r.message]
     assert mismatch_warnings, "expected a content-mismatch warning"
     assert "issue 1" in mismatch_warnings[0].message
-
-
-# ---------------------------------------------------------------------------
-# collate_entities: directory-type errors
-# ---------------------------------------------------------------------------
-
-
-def test_collate_entities_rejects_non_directory_repo() -> None:
-    """Passing a file path as ``repo_dir`` raises ``NotADirectoryError``."""
-    with (
-        yaml_disk({"not_a_dir.txt": "just a file"}) as d,
-        pytest.raises(NotADirectoryError, match="not a directory"),
-    ):
-        collate_entities(d / "not_a_dir.txt", d / "out", do_overwrite=True)
-
-
-def test_collate_entities_rejects_directory_in_output_slot() -> None:
-    """If a target output path exists as a directory, raise even with do_overwrite=True."""
-    tree = {
-        "repo/src/MEDS_DEV/datasets/MIMIC-IV/dataset.yaml": {"metadata": {"description": "foo"}},
-        # An existing directory at the spot the collator wants to write datasets.json.
-        "out/datasets.json/": {".gitkeep": ""},
-    }
-    with yaml_disk(tree) as d, pytest.raises(IsADirectoryError, match="is a directory"):
-        collate_entities(d / "repo", d / "out", do_overwrite=True)
-
-
-# ---------------------------------------------------------------------------
-# _walk_ancestors: filesystem-root defensive return
-# ---------------------------------------------------------------------------
-
-
-def test_walk_ancestors_terminates_when_leaf_is_not_under_root() -> None:
-    """If ``leaf`` isn't actually under ``root``, the walk must stop at the filesystem root rather than loop
-    forever.
-
-    Triggers the ``parent == parent.parent`` guard.
-    """
-    ancestors = list(_walk_ancestors(Path("/some/leaf/path"), Path("/totally/different/tree")))
-    # The yielded sequence ends at "/" once the guard fires.
-    assert ancestors[-1] == Path("/")
-    # And nothing under the bogus root is in the result.
-    bogus_root = Path("/totally/different/tree")
-    assert not any(bogus_root in a.parents or a == bogus_root for a in ancestors)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,139 @@
+"""Coverage for ``MEDS_DEV.web`` paths that aren't exercised by the in-module doctests.
+
+The doctests in the web module cover the happy paths and the most common error paths. This file
+fills in the rest: parse-error / error-threshold paths in ``aggregate_results``, the directory-type
+errors in ``collate_entities``, and the ``main`` CLI entry points (which are tedious to exercise
+from doctests but trivial to call with a monkeypatched ``sys.argv``).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from MEDS_DEV.web.aggregate_results import aggregate_results
+from MEDS_DEV.web.aggregate_results import main as aggregate_main
+from MEDS_DEV.web.collate_entities import collate_entities
+from MEDS_DEV.web.collate_entities import main as collate_main
+
+# ---------------------------------------------------------------------------
+# aggregate_results: error paths
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_results_logs_and_skips_unparseable_blob(tmp_path: Path, caplog) -> None:
+    """A single malformed result.json is logged but doesn't abort aggregation."""
+    (tmp_path / "1").mkdir()
+    (tmp_path / "1" / "result.json").write_text('{"valid": "json"}')
+    (tmp_path / "2").mkdir()
+    (tmp_path / "2" / "result.json").write_text("{not valid json")
+
+    out = tmp_path / "all_results.json"
+    with caplog.at_level("WARNING"):
+        agg = aggregate_results(tmp_path, out)
+
+    assert "1" in agg, "valid blob should be aggregated"
+    assert "2" not in agg, "malformed blob should be skipped"
+    assert any("Failed to read" in r.message for r in caplog.records)
+
+
+def test_aggregate_results_aborts_when_error_threshold_exceeded(tmp_path: Path) -> None:
+    """If parse errors exceed ``error_threshold``, aggregation raises."""
+    for i in range(5):
+        (tmp_path / str(i)).mkdir()
+        (tmp_path / str(i) / "result.json").write_text("{not valid json")
+
+    out = tmp_path / "all_results.json"
+    with pytest.raises(ValueError, match="Too many parse errors"):
+        aggregate_results(tmp_path, out, error_threshold=2)
+
+
+# ---------------------------------------------------------------------------
+# collate_entities: directory-type errors
+# ---------------------------------------------------------------------------
+
+
+def test_collate_entities_rejects_non_directory_repo(tmp_path: Path) -> None:
+    """Passing a file path as ``repo_dir`` raises ``NotADirectoryError``."""
+    file_as_repo = tmp_path / "not_a_dir"
+    file_as_repo.write_text("just a file")
+    with pytest.raises(NotADirectoryError, match="not a directory"):
+        collate_entities(file_as_repo, tmp_path / "out", do_overwrite=True)
+
+
+def test_collate_entities_rejects_directory_in_output_slot(tmp_path: Path) -> None:
+    """If a target output path exists as a directory, raise even with do_overwrite=True."""
+    repo = tmp_path / "repo"
+    (repo / "src" / "MEDS_DEV" / "datasets" / "MIMIC-IV").mkdir(parents=True)
+    (repo / "src" / "MEDS_DEV" / "datasets" / "MIMIC-IV" / "dataset.yaml").write_text(
+        "metadata:\n  description: foo\n"
+    )
+
+    out = tmp_path / "out"
+    out.mkdir()
+    (out / "datasets.json").mkdir()  # collide with the file the collator wants to write
+
+    with pytest.raises(IsADirectoryError, match="is a directory"):
+        collate_entities(repo, out, do_overwrite=True)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry points
+# ---------------------------------------------------------------------------
+
+
+def test_collate_main_cli(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``meds-dev-collate-entities`` writes the three manifests to the output directory."""
+    repo = tmp_path / "repo"
+    (repo / "src" / "MEDS_DEV" / "datasets" / "MIMIC-IV").mkdir(parents=True)
+    (repo / "src" / "MEDS_DEV" / "datasets" / "MIMIC-IV" / "dataset.yaml").write_text(
+        "metadata:\n  description: foo\n"
+    )
+    (repo / "src" / "MEDS_DEV" / "tasks" / "mortality").mkdir(parents=True)
+    (repo / "src" / "MEDS_DEV" / "tasks" / "mortality" / "first_24h.yaml").write_text("predicates: {a: b}\n")
+    (repo / "src" / "MEDS_DEV" / "models" / "rp").mkdir(parents=True)
+    (repo / "src" / "MEDS_DEV" / "models" / "rp" / "model.yaml").write_text("metadata:\n  description: rp\n")
+
+    out = tmp_path / "out"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meds-dev-collate-entities",
+            "--repo_dir",
+            str(repo),
+            "--output_dir",
+            str(out),
+            "--do_overwrite",
+        ],
+    )
+    collate_main()
+
+    assert {p.name for p in out.iterdir()} == {"datasets.json", "tasks.json", "models.json"}
+    datasets = json.loads((out / "datasets.json").read_text())
+    assert "MIMIC-IV" in datasets
+
+
+def test_aggregate_main_cli(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``meds-dev-aggregate-results`` writes a populated all_results.json."""
+    in_dir = tmp_path / "_results"
+    in_dir.mkdir()
+    (in_dir / "42").mkdir()
+    (in_dir / "42" / "result.json").write_text('{"value": "from-cli"}')
+
+    out = tmp_path / "all_results.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "meds-dev-aggregate-results",
+            "--input_dir",
+            str(in_dir),
+            "--output_path",
+            str(out),
+        ],
+    )
+    aggregate_main()
+
+    assert json.loads(out.read_text()) == {"42": {"value": "from-cli"}}

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,8 +1,9 @@
 """End-to-end CLI tests for ``MEDS_DEV.web``.
 
 The doctests in ``aggregate_results.py`` and ``collate_entities.py`` cover happy paths, error paths,
-and the log-output contract (via the ``capture_log_to_stdout`` helper). This file is just the
-subprocess-based CLI tests, which can't live in doctests without bloating them with shell setup.
+and the log-output contract (via pytest's ``caplog`` fixture, injected into the doctest namespace).
+This file is just the subprocess-based CLI tests, which can't live in doctests without bloating
+them with shell setup.
 """
 
 import json
@@ -12,7 +13,8 @@ from yaml_to_disk import yaml_disk
 
 
 def test_collate_entities_cli() -> None:
-    """``meds-dev-collate-entities`` writes the three manifests to the output directory."""
+    """``meds-dev-collate-entities`` writes the three manifests; their contents match the source tree
+    deterministically."""
     tree = {
         "repo/src/MEDS_DEV/": {
             "datasets/MIMIC-IV/dataset.yaml": {"metadata": {"description": "foo"}},
@@ -35,15 +37,42 @@ def test_collate_entities_cli() -> None:
             capture_output=True,
             text=True,
         )
+
         assert result.returncode == 0
         assert {p.name for p in out.iterdir()} == {"datasets.json", "tasks.json", "models.json"}
-        datasets = json.loads((out / "datasets.json").read_text())
-        assert "MIMIC-IV" in datasets
+
+        assert json.loads((out / "datasets.json").read_text()) == {
+            "MIMIC-IV": {
+                "name": "MIMIC-IV",
+                "data": {"type": "dataset", "entity": {"metadata": {"description": "foo"}}},
+                "children": [],
+            }
+        }
+        assert json.loads((out / "tasks.json").read_text()) == {
+            "mortality/first_24h": {
+                "name": "mortality/first_24h",
+                "data": {"type": "task", "entity": {"predicates": {"a": "b"}}},
+                "children": [],
+            }
+        }
+        assert json.loads((out / "models.json").read_text()) == {
+            "rp": {
+                "name": "rp",
+                "data": {"type": "model", "entity": {"metadata": {"description": "rp"}}},
+                "children": [],
+            }
+        }
 
 
 def test_aggregate_results_cli() -> None:
-    """``meds-dev-aggregate-results`` writes a populated all_results.json."""
-    tree = {"_results/42/result.json": {"value": "from-cli"}}
+    """``meds-dev-aggregate-results`` writes all results to a single aggregated file."""
+    tree = {
+        "_results/": {
+            "42/result.json": {"model": "a", "score": 0.91},
+            "43/result.json": {"model": "b", "score": 0.85},
+            "44/result.json": {"model": "c", "score": 0.78},
+        }
+    }
     with yaml_disk(tree) as d:
         out = d / "all_results.json"
         result = subprocess.run(
@@ -58,5 +87,10 @@ def test_aggregate_results_cli() -> None:
             capture_output=True,
             text=True,
         )
+
         assert result.returncode == 0
-        assert json.loads(out.read_text()) == {"42": {"value": "from-cli"}}
+        assert json.loads(out.read_text()) == {
+            "42": {"model": "a", "score": 0.91},
+            "43": {"model": "b", "score": 0.85},
+            "44": {"model": "c", "score": 0.78},
+        }

--- a/uv.lock
+++ b/uv.lock
@@ -294,9 +294,11 @@ dependencies = [
 dev = [
     { name = "meds-testing-helpers" },
     { name = "pre-commit" },
+    { name = "pretty-print-directory" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "yaml-to-disk" },
 ]
 
 [package.metadata]
@@ -313,9 +315,11 @@ requires-dist = [
 dev = [
     { name = "meds-testing-helpers" },
     { name = "pre-commit", specifier = "<4" },
+    { name = "pretty-print-directory" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "yaml-to-disk" },
 ]
 
 [[package]]
@@ -520,6 +524,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/64/10/97ee2fa54dff1e9da9badbc5e35d0bbaef0776271ea5907eccf64140f72f/pre_commit-3.8.0.tar.gz", hash = "sha256:8bb6494d4a20423842e198980c9ecf9f96607a07ea29549e180eef9ae80fe7af", size = 177815, upload-time = "2024-07-28T19:59:01.538Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/92/caae8c86e94681b42c246f0bca35c059a2f0529e5b92619f6aba4cf7e7b6/pre_commit-3.8.0-py2.py3-none-any.whl", hash = "sha256:9a90a53bf82fdd8778d58085faf8d83df56e40dfe18f45b19446e26bf1b3a63f", size = 204643, upload-time = "2024-07-28T19:58:59.335Z" },
+]
+
+[[package]]
+name = "pretty-print-directory"
+version = "0.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/24/8c34b4ba69b9b5cf7dd1eb442bb98fb483441979ac2edd962fbc805a6553/pretty_print_directory-0.1.3.tar.gz", hash = "sha256:08070aee8aee9101455ef8bacf2d540757a2ca84dae93f223d97defcdb6d3fff", size = 13577, upload-time = "2025-07-09T18:03:33.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/eb/6bad26f6d0a7fc6dc2aaa53caced96b46d3fd112686ccfa5559da6bb09da/pretty_print_directory-0.1.3-py3-none-any.whl", hash = "sha256:e651113270a3db0dda524dd3f53dd2a1e98f7927c4c2fa0ddc73e8dc985dc8e6", size = 8326, upload-time = "2025-07-09T18:03:31.854Z" },
 ]
 
 [[package]]
@@ -1087,4 +1103,17 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
+]
+
+[[package]]
+name = "yaml-to-disk"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/31/ec/6010796bcc6a0294eae073fd14986ca37387d6e53cd4ceb1e54154018b8e/yaml_to_disk-0.0.5.tar.gz", hash = "sha256:972d077fada66444210ada75e72ee789a640861d60b9368040080b91492f91fe", size = 96162, upload-time = "2026-04-24T15:14:24.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/11/be763a4f337032e2ec4b1b9bbf267d8b35f4e60a831b59b4ac5ca2ad30d9/yaml_to_disk-0.0.5-py3-none-any.whl", hash = "sha256:2fac9794d5ff22dfef96707038017a3288eea2b1d490fd680cebd37373e972db", size = 21568, upload-time = "2026-04-24T15:14:23.076Z" },
 ]


### PR DESCRIPTION
## Summary

Promotes the `MEDS_DEV.web` module out of the unmerged [`add_web_scripts`](https://github.com/Medical-Event-Data-Standard/MEDS-DEV/tree/add_web_scripts) branch and into the package, adapted to current source layout. Resolves #280.

## What changes

- **`src/MEDS_DEV/web/collate_entities.py`** — walks `src/MEDS_DEV/{datasets,tasks,models}/` and emits the JSON manifests (`datasets.json`, `tasks.json`, `models.json`) that the website fetches at runtime. Schema matches `parse_tree.ts`/`types.ts` in the website repo. Adapted to handle:
  - Datasets/models: leaves are directories containing `dataset.yaml` / `model.yaml`, with optional sibling files (`README.md`, `refs.bib`, `predicates.yaml`, `requirements.txt`)
  - Tasks: leaves are bare `*.yaml` files (current convention — original prototype assumed `task.yaml` per directory)
  - Categories: ancestor directories with a `README.md` become parent nodes; ones without are skipped (matches prototype behavior)
  - Hydra missing-value placeholders (`???`) survive serialization as the literal string `"???"`
- **`src/MEDS_DEV/web/aggregate_results.py`** — reads `<input>/<id>/result.json` blobs and aggregates into a single JSON file keyed by id. Idempotent: existing entries are preserved; only new keys are added.
- **`pyproject.toml`**:
  - Registers two CLIs: `meds-dev-collate-entities`, `meds-dev-aggregate-results`
  - Turns on `doctest_optionflags = "ELLIPSIS NORMALIZE_WHITESPACE"` globally so doctests across the project can use `...` for path/timestamp variability without per-block directives

## Verification

Ran against the live source tree:

```
=== datasets: 1 entries ===
  MIMIC-IV -> (leaf)
=== tasks: 11 entries ===
  abnormal_lab -> 7 children
  ... (all 8 tasks captured + 3 categories)
=== models: 5 entries ===
  cehrbert, genhpf, meds_tab -> meds_tab/tiny, random_predictor (4 leaves + 1 category)
```

Ran `meds-dev-aggregate-results` against the live `_results` branch — produces 32 entries, matching what's currently on `_web/results/all_results.json`.

8 new doctests pass; full fast lane (44 tests) still passes.

## What's *not* in this PR

- The workflow that *runs* this regeneration on source changes (#281)
- Folding aggregation into the inline submission flow (#238)
- Updating `_web/scripts/aggregate_results.py` to invoke the package version (downstream of this)

## Notes for reviewers

- AUMCdb is not picked up because it has no `dataset.yaml` (only `predicates.yaml` and `README.md`). That's correct per the registry — incomplete datasets are not registered. Will be handled separately when AUMCdb is fully wired up.
- I went with `OmegaConf.to_container(..., throw_on_missing=False)` instead of `yaml.safe_load` to match the rest of the package and to preserve `???` placeholders without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
