### PR TITLE
Chain Aggregate Benchmark Results via workflow_call from submission flow

### DIFF
--- a/.github/workflows/aggregate_benchmark_results.yaml
+++ b/.github/workflows/aggregate_benchmark_results.yaml
@@ -1,9 +1,11 @@
 name: Aggregate Benchmark Results
 
+# Manual fallback for re-aggregating _results into _web. Per-submission
+# aggregation is now handled inline by upload_benchmark_result.yaml (#238),
+# so this workflow is intended only for ad-hoc reruns (e.g., recovering from
+# a missed submission).
 on:
   workflow_dispatch:
-  push:
-    branches: [_results]
 
 permissions:
   contents: write
@@ -19,30 +21,37 @@ jobs:
           ref: _results
           path: results-branch
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-
       - name: Check out _web branch
         uses: actions/checkout@v4
         with:
           ref: _web
           path: web-branch
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install MEDS-DEV from PyPI
+        run: pip install meds-dev
+
       - name: Aggregate results
         run: |
-          mkdir web-branch/results -p
-          python web-branch/scripts/aggregate_results.py \
+          mkdir -p web-branch/results
+          meds-dev-aggregate-results \
             --input_dir results-branch/_results \
             --output_path web-branch/results/all_results.json
 
-      - name: Commit and push to docs branch
+      - name: Commit and push to _web branch
         if: success()
+        working-directory: web-branch
         run: |
-          cd web-branch
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
           git add results/all_results.json
-          git commit -m "Update aggregated results from _results" || echo "No changes to commit"
-          git push origin _web
+          if git diff --cached --quiet; then
+            echo "No changes to all_results.json; skipping commit."
+          else
+            git commit -m "Update aggregated results from _results (manual run)"
+            git push origin _web
+          fi

--- a/.github/workflows/aggregate_benchmark_results.yaml
+++ b/.github/workflows/aggregate_benchmark_results.yaml
@@ -1,11 +1,13 @@
 name: Aggregate Benchmark Results
 
-# Manual fallback for re-aggregating _results into _web. Per-submission
-# aggregation is now handled inline by upload_benchmark_result.yaml (#238),
-# so this workflow is intended only for ad-hoc reruns (e.g., recovering from
-# a missed submission).
+# Single source of truth for _results -> _web aggregation. Reusable:
+#  - workflow_call: invoked by upload_benchmark_result.yaml after a new
+#    submission lands on _results (#238)
+#  - workflow_dispatch: manual fallback (e.g., to repair _web after a
+#    failed automatic run, or to backfill before this workflow existed).
 on:
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: write
@@ -52,6 +54,6 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to all_results.json; skipping commit."
           else
-            git commit -m "Update aggregated results from _results (manual run)"
+            git commit -m "Update aggregated results from _results"
             git push origin _web
           fi

--- a/.github/workflows/upload_benchmark_result.yaml
+++ b/.github/workflows/upload_benchmark_result.yaml
@@ -6,33 +6,33 @@ on:
       - labeled
 
 # Serialize submissions so two near-simultaneous label events don't race on
-# pushes to the _results / _web branches (#236).
+# pushes to the _results branch (#236).
 concurrency:
   group: upload-benchmark-results
   cancel-in-progress: false
 
 jobs:
-  process_results:
+  # ----------------------------------------------------------------------
+  # Job 1: validate the submission and commit it to the _results branch.
+  # ----------------------------------------------------------------------
+  process_submission:
     if: contains(github.event.issue.labels.*.name, 'result-submission') && startsWith(github.event.issue.title, '[Result Submission]')
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      issues: write
     steps:
       - name: Checkout _results branch
         uses: actions/checkout@v4
         with:
           ref: _results
-          path: results-branch
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract JSON from issue body
         env:
           ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          # Write the raw issue body to a file via env var (avoids shell
-          # injection from arbitrary issue body content) then strip down to
-          # the fenced ```json ... ``` block.
+          # Route the issue body through an env var to avoid shell injection
+          # from arbitrary user content, then strip down to the ```json``` block.
           printf '%s' "$ISSUE_BODY" > issue_body.txt
           sed -n '/```json/,/```/p' issue_body.txt | sed '1d;$d' > "$GITHUB_WORKSPACE/result.json"
 
@@ -60,7 +60,6 @@ jobs:
           ISSUE_USER_LOGIN: ${{ github.event.issue.user.login }}
           ISSUE_USER_ID: ${{ github.event.issue.user.id }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-        working-directory: results-branch
         run: |
           mkdir -p "_results/${ISSUE_NUMBER}"
           mv "$GITHUB_WORKSPACE/result.json" "_results/${ISSUE_NUMBER}/result.json"
@@ -72,46 +71,31 @@ jobs:
           git commit -m "Added result from Issue #${ISSUE_NUMBER} by @${ISSUE_USER_LOGIN}"
           git push origin _results
 
-      # ------------------------------------------------------------------
-      # Aggregation step — runs in the same workflow as the submission to
-      # work around GitHub's "GITHUB_TOKEN-pushed commits don't trigger
-      # downstream workflows" rule (#238). The standalone Aggregate Benchmark
-      # Results workflow is preserved for manual workflow_dispatch use.
-      # ------------------------------------------------------------------
-      - name: Checkout _web branch
-        uses: actions/checkout@v4
-        with:
-          ref: _web
-          path: web-branch
-          token: ${{ secrets.GITHUB_TOKEN }}
+  # ----------------------------------------------------------------------
+  # Job 2: invoke the canonical aggregation workflow.
+  #
+  # GITHUB_TOKEN pushes don't fire downstream workflows (anti-recursion
+  # safeguard, see #238), so we can't rely on `on: push: branches:
+  # [_results]` to chain the aggregator. Calling it via workflow_call is
+  # the explicit equivalent: one source of truth for _results -> _web,
+  # invocable both here and via manual workflow_dispatch.
+  # ----------------------------------------------------------------------
+  aggregate:
+    needs: process_submission
+    uses: ./.github/workflows/aggregate_benchmark_results.yaml
+    permissions:
+      contents: write
 
-      - name: Aggregate _results into _web/results/all_results.json
-        env:
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          mkdir -p web-branch/results
-          meds-dev-aggregate-results \
-            --input_dir results-branch/_results \
-            --output_path web-branch/results/all_results.json
-
-      - name: Commit aggregated results to _web branch
-        working-directory: web-branch
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add results/all_results.json
-          # No-op commits are fine: keep the workflow green if the aggregator
-          # decided nothing changed (e.g., a re-run on an already-aggregated
-          # issue).
-          if git diff --cached --quiet; then
-            echo "No changes to all_results.json; skipping commit."
-          else
-            git commit -m "Update aggregated results from _results"
-            git push origin _web
-          fi
-
+  # ----------------------------------------------------------------------
+  # Job 3: close the submission issue once aggregation has shipped.
+  # ----------------------------------------------------------------------
+  close_issue:
+    needs: aggregate
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
       - name: Close issue with confirmation message
-        if: success()
         uses: peter-evans/close-issue@v3.0.2
         with:
-          comment: "Thank you for your submission! Your result has been recorded, validated, and aggregated."
+          comment: "Thank you for your submission! Your result has been recorded, aggregated, and is now visible on the leaderboard."

--- a/.github/workflows/upload_benchmark_result.yaml
+++ b/.github/workflows/upload_benchmark_result.yaml
@@ -5,6 +5,12 @@ on:
     types:
       - labeled
 
+# Serialize submissions so two near-simultaneous label events don't race on
+# pushes to the _results / _web branches (#236).
+concurrency:
+  group: upload-benchmark-results
+  cancel-in-progress: false
+
 jobs:
   process_results:
     if: contains(github.event.issue.labels.*.name, 'result-submission') && startsWith(github.event.issue.title, '[Result Submission]')
@@ -13,50 +19,99 @@ jobs:
       contents: write
       issues: write
     steps:
-      - name: Checkout results branch only
+      - name: Checkout _results branch
         uses: actions/checkout@v4
         with:
           ref: _results
+          path: results-branch
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract JSON from issue body
-        id: extract_json
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          echo '${{ github.event.issue.body }}' > issue_body.txt
-          sed -n '/```json/,/```/p' issue_body.txt | sed '1d;$d' > $GITHUB_WORKSPACE/result.json
+          # Write the raw issue body to a file via env var (avoids shell
+          # injection from arbitrary issue body content) then strip down to
+          # the fenced ```json ... ``` block.
+          printf '%s' "$ISSUE_BODY" > issue_body.txt
+          sed -n '/```json/,/```/p' issue_body.txt | sed '1d;$d' > "$GITHUB_WORKSPACE/result.json"
 
-          if [[ ! -s $GITHUB_WORKSPACE/result.json ]]; then
+          if [[ ! -s "$GITHUB_WORKSPACE/result.json" ]]; then
             echo "ERROR: No valid JSON found in the issue body."
             exit 1
           fi
 
           echo "Extracted JSON:"
-          cat $GITHUB_WORKSPACE/result.json
+          cat "$GITHUB_WORKSPACE/result.json"
 
-      - name: Install MEDS-DEV package from PyPI
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install MEDS-DEV from PyPI
         run: pip install meds-dev
 
       - name: Validate result JSON
-        run: meds-dev-validate-result result_fp=$GITHUB_WORKSPACE/result.json
+        run: meds-dev-validate-result result_fp="$GITHUB_WORKSPACE/result.json"
 
-      - name: Commit result attributed to issue author
-        if: success()
+      - name: Commit result to _results branch
         env:
           ISSUE_USER_LOGIN: ${{ github.event.issue.user.login }}
           ISSUE_USER_ID: ${{ github.event.issue.user.id }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        working-directory: results-branch
         run: |
-          mkdir -p _results/${{ github.event.issue.number }}
-          mv $GITHUB_WORKSPACE/result.json _results/${{ github.event.issue.number }}/result.json
-          git add _results/${{ github.event.issue.number }}/result.json
+          mkdir -p "_results/${ISSUE_NUMBER}"
+          mv "$GITHUB_WORKSPACE/result.json" "_results/${ISSUE_NUMBER}/result.json"
+          git add "_results/${ISSUE_NUMBER}/result.json"
 
           git config user.name "${ISSUE_USER_LOGIN}"
           git config user.email "${ISSUE_USER_ID}+${ISSUE_USER_LOGIN}@users.noreply.github.com"
 
-          git commit -m "Added result from Issue #${{ github.event.issue.number }} by @${ISSUE_USER_LOGIN}"
+          git commit -m "Added result from Issue #${ISSUE_NUMBER} by @${ISSUE_USER_LOGIN}"
           git push origin _results
+
+      # ------------------------------------------------------------------
+      # Aggregation step — runs in the same workflow as the submission to
+      # work around GitHub's "GITHUB_TOKEN-pushed commits don't trigger
+      # downstream workflows" rule (#238). The standalone Aggregate Benchmark
+      # Results workflow is preserved for manual workflow_dispatch use.
+      # ------------------------------------------------------------------
+      - name: Checkout _web branch
+        uses: actions/checkout@v4
+        with:
+          ref: _web
+          path: web-branch
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Aggregate _results into _web/results/all_results.json
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          mkdir -p web-branch/results
+          meds-dev-aggregate-results \
+            --input_dir results-branch/_results \
+            --output_path web-branch/results/all_results.json
+
+      - name: Commit aggregated results to _web branch
+        working-directory: web-branch
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add results/all_results.json
+          # No-op commits are fine: keep the workflow green if the aggregator
+          # decided nothing changed (e.g., a re-run on an already-aggregated
+          # issue).
+          if git diff --cached --quiet; then
+            echo "No changes to all_results.json; skipping commit."
+          else
+            git commit -m "Update aggregated results from _results"
+            git push origin _web
+          fi
 
       - name: Close issue with confirmation message
         if: success()
-        uses: peter-evans/close-issue@v2
+        uses: peter-evans/close-issue@v3.0.2
         with:
-          comment: "Thank you for your submission! Your result has been recorded and validated."
+          comment: "Thank you for your submission! Your result has been recorded, validated, and aggregated."


### PR DESCRIPTION
## Summary

Resolves #238 by giving `_results` → `_web` aggregation a single source of truth, invoked both automatically (after a result submission) and manually (`workflow_dispatch`).

> [!IMPORTANT]
> **Targets `feat/web-tooling` (#283).** The new `meds-dev-aggregate-results` CLI introduced there is what these workflows invoke. The diff on this PR shows only the workflow changes — the package additions are reviewed in #283. When #283 merges to `dev`, GitHub will auto-retarget this PR to `dev`.

## The original bug (#238)

The submission workflow pushed to `_results` using the default `GITHUB_TOKEN`. Per [GitHub's documented behavior](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow):
> When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN` will not create a new workflow run.

So `aggregate_benchmark_results.yaml`'s `on: push: branches: [_results]` trigger never actually fired. Last 5 runs were all manual `workflow_dispatch` (most recent: 2025-10-21 — submission #262 from 2025-10-17 was never auto-aggregated).

## The fix: `workflow_call` chaining

Rather than inline the aggregation into the submission workflow (which duplicates the aggregator logic), use GitHub's reusable-workflow feature.

- **`aggregate_benchmark_results.yaml`** declares both `workflow_dispatch:` (manual) and `workflow_call:` (callable from other workflows). Single source of truth for `_results` → `_web`.
- **`upload_benchmark_result.yaml`** becomes a three-job pipeline:
  1. `process_submission` — validate JSON, commit `result.json` to `_results`
  2. `aggregate` — `uses: ./.github/workflows/aggregate_benchmark_results.yaml`
  3. `close_issue` — close with success message once aggregation has shipped

If aggregation fails, the submission is durable in `_results` and the issue stays open until a manual `workflow_dispatch` repairs `_web`.

## Other improvements bundled in

- **Concurrency group** (`upload-benchmark-results`) so back-to-back label events serialize on `_results` pushes (#236).
- **Shell-injection hardening**: `github.event.issue.body` is routed through an `ISSUE_BODY` env var instead of inlined into a shell command.
- **`peter-evans/close-issue` v2 → v3.0.2** (pinned).
- **No-op-skip on the `_web` push**: idempotent re-runs no longer create empty commits.

## Future cleanup (not in this PR)

- `_web/scripts/aggregate_results.py` on the `_web` branch is now redundant — both workflows invoke the packaged CLI. Can be removed after this PR ships and a release is cut.

## Test plan

- [ ] After merge to dev → main and a release with the new CLI, file a sandbox result-submission and confirm `_results` and `_web` both update in the same workflow run.
- [ ] Manual `workflow_dispatch` on `aggregate_benchmark_results.yaml` still works as a fallback.

## Related

- Targets #283 (web tooling in package) — auto-retargets to `dev` when #283 merges
- Fixes #238
- Mitigates #236 via concurrency group

🤖 Generated with [Claude Code](https://claude.com/claude-code)
