### PR TITLE
Auto-regenerate _web entity manifests on source changes

### DIFF
--- a/.github/workflows/regenerate_entities.yaml
+++ b/.github/workflows/regenerate_entities.yaml
@@ -1,0 +1,66 @@
+name: Regenerate _web Entity Manifests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/MEDS_DEV/datasets/**"
+      - "src/MEDS_DEV/tasks/**"
+      - "src/MEDS_DEV/models/**"
+      - "src/MEDS_DEV/web/collate_entities.py"
+  workflow_dispatch:
+
+# Each run regenerates from main's latest state, so a newer run supersedes
+# any in-flight one — cancelling saves the wasted regen.
+concurrency:
+  group: regenerate-entities
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          path: main-branch
+
+      - name: Checkout _web branch
+        uses: actions/checkout@v4
+        with:
+          ref: _web
+          path: web-branch
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install MEDS-DEV from source
+        # Install from the just-checked-out main rather than from PyPI so the
+        # regenerated manifests reflect the merged commit, not the last release.
+        run: pip install ./main-branch
+
+      - name: Regenerate entity manifests
+        run: |
+          mkdir -p web-branch/entities
+          meds-dev-collate-entities \
+            --repo_dir main-branch \
+            --output_dir web-branch/entities \
+            --do_overwrite
+
+      - name: Commit and push to _web
+        working-directory: web-branch
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add entities/datasets.json entities/tasks.json entities/models.json
+          if git diff --cached --quiet; then
+            echo "No changes to entity manifests; skipping commit."
+          else
+            git commit -m "Regenerate entity manifests from main@${GITHUB_SHA::7}"
+            git push origin _web
+          fi


### PR DESCRIPTION
## Summary

Adds `.github/workflows/regenerate_entities.yaml` to keep `_web/entities/{datasets,tasks,models}.json` in sync with the source tree automatically. Resolves #281 and the automation half of #186, #187, #188.

> [!IMPORTANT]
> **Targets `ci/inline-aggregate-results` (#284), which targets `feat/web-tooling` (#283).** The diff on this PR shows only the new workflow file. The CLI it invokes is in #283. When #284 merges, GitHub will auto-retarget this PR to whatever #284 was pointing at; same chain.

## Trigger

```yaml
on:
  push:
    branches: [main]
    paths:
      - "src/MEDS_DEV/datasets/**"
      - "src/MEDS_DEV/tasks/**"
      - "src/MEDS_DEV/models/**"
      - "src/MEDS_DEV/web/collate_entities.py"
  workflow_dispatch:
```

Path filter ensures unrelated commits to main don't trigger a regeneration.

## How it works

1. Checks out `main` (with the new dataset/task/model) and `_web` (target for the manifests) into separate paths.
2. `pip install ./main-branch` so the CLI reflects the merged commit, not whatever's on PyPI. (Important — if it installed from PyPI we'd be a release behind on the schema.)
3. Runs `meds-dev-collate-entities --repo_dir main-branch --output_dir web-branch/entities --do_overwrite`.
4. Commits and pushes to `_web`. Skips the commit when the collator produces no diff (idempotent re-runs).

## Why not pin to a PyPI release?

We considered pinning to `pip install meds-dev>=<min>` but that means the _web manifest lags behind every dataset/task/model change until a release is cut. Installing from the just-checked-out commit makes the _web update real-time, which is what users will expect ("I added a dataset to main, why isn't it on the website?").

## Why no _web → website trigger?

The website (medical-event-data-standard.github.io) fetches `_web` raw URLs at runtime via `loadAndCache.ts` with a TTL. There's no build-time dependency on `_web`, so we don't need to trigger a website rebuild after pushing. (See #287 for the full pipeline doc this is part of.)

## Test plan

- [ ] After this PR merges and the previous two ship, push a change to a dataset/task/model on main and confirm `_web/entities/*.json` updates.
- [ ] Manual `workflow_dispatch` run produces the expected diff (matches `meds-dev-collate-entities` output locally).

## Related

- Stacked on #283, #284
- Resolves #281, the automation half of #186 / #187 / #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)