### PR TITLE
Address Copilot review feedback on PR #279

### DIFF
--- a/.github/scripts/select_test_scope.py
+++ b/.github/scripts/select_test_scope.py
@@ -113,9 +113,7 @@ def classify_changes(changed_files: list[str]) -> dict:
         # Check task-scoped — resolve to logical task name (slash-separated, no .yaml)
         m = TASK_PATTERN.match(filepath)
         if m:
-            task_name = m.group(1)
-            # Strip leading path component that is the tasks package itself
-            changed_tasks.add(task_name)
+            changed_tasks.add(m.group(1))
             continue
 
         # Check model-scoped

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,12 +41,14 @@ jobs:
       - name: Determine test scope
         id: scope
         run: |
-          # Manual dispatch overrides (only fast or full — no affected, since there's no PR diff context)
+          # Manual dispatch overrides (only fast or full — no affected, since there's no PR diff context).
+          # Lanes skip naturally when the changed_* outputs are all empty, so we don't conflate
+          # "manual fast scope override" with "actual docs-only diff" by flipping docs_only.
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             SCOPE="${{ github.event.inputs.scope }}"
             if [[ "$SCOPE" == "fast" ]]; then
               echo "run_full=false" >> "$GITHUB_OUTPUT"
-              echo "docs_only=true" >> "$GITHUB_OUTPUT"
+              echo "docs_only=false" >> "$GITHUB_OUTPUT"
               echo "changed_datasets=[]" >> "$GITHUB_OUTPUT"
               echo "changed_tasks=[]" >> "$GITHUB_OUTPUT"
               echo "changed_models=[]" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Two small clarity-only edits in response to Copilot's review on #279. No behavior change.

- **`tests.yaml`** — `docs_only=true` was being set in the manual `workflow_dispatch fast` path even though the run isn't actually for a docs-only diff. The empty `changed_*` arrays already make every lane skip, so flipping `docs_only` was redundant *and* misleading in the scope summary. Now `docs_only=false` here.
- **`select_test_scope.py`** — removes a stale "Strip leading path component that is the tasks package itself" comment. The `TASK_PATTERN` regex already captures the relative task path (no `src/MEDS_DEV/tasks/` prefix), so there was nothing to strip.

Once this lands, PR #279 (release roll-up) picks up the fixes automatically since it points at `dev`.

## Test plan

Both changes are non-functional:
- The `docs_only=false` flip is equivalent to the prior code in lane-skipping behavior (verified by inspection: lanes require `docs_only != 'true' && changed_X != '[]'`; with `changed_X = []` the second predicate alone gates the skip)
- The comment removal is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)