### PR TITLE
Chain aggregation via workflow_call from submission flow

### DIFF
--- a/.github/workflows/aggregate_benchmark_results.yaml
+++ b/.github/workflows/aggregate_benchmark_results.yaml
@@ -2,8 +2,7 @@ name: Aggregate Benchmark Results
 
 on:
   workflow_dispatch:
-  push:
-    branches: [_results]
+  workflow_call:
 
 permissions:
   contents: write

--- a/.github/workflows/upload_benchmark_result.yaml
+++ b/.github/workflows/upload_benchmark_result.yaml
@@ -12,12 +12,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  process_results:
+  process_submission:
     if: contains(github.event.issue.labels.*.name, 'result-submission') && startsWith(github.event.issue.title, '[Result Submission]')
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      issues: write
     steps:
       - name: Checkout results branch only
         uses: actions/checkout@v4
@@ -53,8 +52,19 @@ jobs:
           git commit -m "Added result from Issue #${ISSUE_NUMBER} by @${ISSUE_USER_LOGIN}"
           git push origin _results
 
+  aggregate:
+    needs: process_submission
+    uses: ./.github/workflows/aggregate_benchmark_results.yaml
+    permissions:
+      contents: write
+
+  close_issue:
+    needs: aggregate
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
       - name: Close issue with confirmation message
-        if: success()
         uses: peter-evans/close-issue@v3.0.2
         with:
-          comment: "Thank you for your submission! Your result has been recorded and validated."
+          comment: "Thank you for your submission! Your result has been recorded, aggregated, and will soon be visible on the leaderboard."


### PR DESCRIPTION
## Summary

Resolves #238. Stacked on #298 (workflow cleanups).

Replaces the unreliable `push: branches: [_results]` trigger on the aggregator with an explicit `workflow_call:` from the submission workflow, so every accepted submission deterministically rebuilds `_web` in the same workflow run.

## The bug (#238)

The submission workflow pushes to `_results` using the default `GITHUB_TOKEN`. Per [GitHub's documented behavior](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow):

> When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN` will not create a new workflow run.

So `aggregate_benchmark_results.yaml`'s `on: push: branches: [_results]` trigger never actually fired. The last 5 runs were all manual `workflow_dispatch` (most recent: 2025-10-21 — submission #262 from 2025-10-17 was never auto-aggregated).

## The fix

- **`aggregate_benchmark_results.yaml`**: drop `push: branches: [_results]`, add `workflow_call:`. The workflow remains invocable via `workflow_dispatch` for manual reruns.
- **`upload_benchmark_result.yaml`**: split the single job into three:
  1. `process_submission` — validate JSON, commit `result.json` to `_results` (unchanged behavior; just renamed).
  2. `aggregate` — `uses: ./.github/workflows/aggregate_benchmark_results.yaml`.
  3. `close_issue` — `needs: aggregate`, posts the closing comment (text updated to mention aggregation completion, which is now true at the time it's posted).

If aggregation fails, the submission is durable in `_results` and the issue stays open until a manual `workflow_dispatch` repairs `_web`.

## Note on `uses: ./` resolution

`uses: ./.github/workflows/aggregate_benchmark_results.yaml` resolves the reusable workflow against the **git ref of the calling workflow**, not the runner filesystem. For our `on: issues: labeled` trigger that ref is always the default branch (main), so the `actions/checkout@v4` of `_results` in the first job has no bearing on workflow resolution — they're independent concerns. This is also why we can't fully validate the chain in a PR before merge: in any PR, `uses: ./` keeps resolving to main's copy of the aggregator, not the PR's. (Tracked separately in #293 for `act`-based smoke tests.)

## Test plan

- [ ] After merge (this + #298) and a release that ships the new CLI, file a sandbox `[Result Submission]` issue. Confirm `_results/<n>/result.json` lands, `_web` updates, and the issue closes with the aggregated-mention message — all in the same workflow run.
- [ ] Manual `workflow_dispatch` on `aggregate_benchmark_results.yaml` still works as a fallback.

## Related

- Stacked on #298 (workflow cleanups).
- Fixes #238.
- Builds on #295 (`meds-dev-process-submission` CLI, now in dev).
- Supersedes #284 (closed because base branch was deleted on merge of #283).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
