### PR TITLE
Add actionlint to pre-commit

### DIFF
--- a/.github/workflows/upload_benchmark_result.yaml
+++ b/.github/workflows/upload_benchmark_result.yaml
@@ -21,17 +21,20 @@ jobs:
 
       - name: Extract JSON from issue body
         id: extract_json
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          echo '${{ github.event.issue.body }}' > issue_body.txt
-          sed -n '/```json/,/```/p' issue_body.txt | sed '1d;$d' > $GITHUB_WORKSPACE/result.json
+          # Route through env var to avoid shell injection from arbitrary issue body content.
+          printf '%s' "$ISSUE_BODY" > issue_body.txt
+          sed -n '/```json/,/```/p' issue_body.txt | sed '1d;$d' > "$GITHUB_WORKSPACE/result.json"
 
-          if [[ ! -s $GITHUB_WORKSPACE/result.json ]]; then
+          if [[ ! -s "$GITHUB_WORKSPACE/result.json" ]]; then
             echo "ERROR: No valid JSON found in the issue body."
             exit 1
           fi
 
           echo "Extracted JSON:"
-          cat $GITHUB_WORKSPACE/result.json
+          cat "$GITHUB_WORKSPACE/result.json"
 
       - name: Install MEDS-DEV package from PyPI
         run: pip install meds-dev

--- a/.github/workflows/upload_benchmark_result.yaml
+++ b/.github/workflows/upload_benchmark_result.yaml
@@ -26,6 +26,7 @@ jobs:
         run: |
           # Route through env var to avoid shell injection from arbitrary issue body content.
           printf '%s' "$ISSUE_BODY" > issue_body.txt
+          # shellcheck disable=SC2016  # single-quotes are intentional — the sed patterns are literal.
           sed -n '/```json/,/```/p' issue_body.txt | sed '1d;$d' > "$GITHUB_WORKSPACE/result.json"
 
           if [[ ! -s "$GITHUB_WORKSPACE/result.json" ]]; then
@@ -40,22 +41,23 @@ jobs:
         run: pip install meds-dev
 
       - name: Validate result JSON
-        run: meds-dev-validate-result result_fp=$GITHUB_WORKSPACE/result.json
+        run: meds-dev-validate-result result_fp="$GITHUB_WORKSPACE/result.json"
 
       - name: Commit result attributed to issue author
         if: success()
         env:
           ISSUE_USER_LOGIN: ${{ github.event.issue.user.login }}
           ISSUE_USER_ID: ${{ github.event.issue.user.id }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          mkdir -p _results/${{ github.event.issue.number }}
-          mv $GITHUB_WORKSPACE/result.json _results/${{ github.event.issue.number }}/result.json
-          git add _results/${{ github.event.issue.number }}/result.json
+          mkdir -p "_results/${ISSUE_NUMBER}"
+          mv "$GITHUB_WORKSPACE/result.json" "_results/${ISSUE_NUMBER}/result.json"
+          git add "_results/${ISSUE_NUMBER}/result.json"
 
           git config user.name "${ISSUE_USER_LOGIN}"
           git config user.email "${ISSUE_USER_ID}+${ISSUE_USER_LOGIN}@users.noreply.github.com"
 
-          git commit -m "Added result from Issue #${{ github.event.issue.number }} by @${ISSUE_USER_LOGIN}"
+          git commit -m "Added result from Issue #${ISSUE_NUMBER} by @${ISSUE_USER_LOGIN}"
           git push origin _results
 
       - name: Close issue with confirmation message

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,12 @@ repos:
     hooks:
       - id: shellcheck
 
+  # GitHub Actions workflow linter (expression syntax, ref validity, shellcheck on run blocks)
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
   # md formatting
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.22

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,11 +51,14 @@ repos:
     hooks:
       - id: shellcheck
 
-  # GitHub Actions workflow linter (expression syntax, ref validity, shellcheck on run blocks)
+  # GitHub Actions workflow linter (expression syntax, ref validity, shellcheck on run blocks).
+  # SC2129 (group multi-line redirects with `{ ... } >> file`) is style-only and conflicts with the
+  # idiomatic GHA pattern of `echo "key=value" >> "$GITHUB_OUTPUT"`; we disable it explicitly.
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.12
     hooks:
       - id: actionlint
+        args: ["-shellcheck=shellcheck -e SC2129"]
 
   # md formatting
   - repo: https://github.com/executablebooks/mdformat


### PR DESCRIPTION
## Summary

Static analysis for the GitHub Actions workflow files. Catches expression-syntax errors, wrong action references, shellcheck issues on inline `run:` blocks, and known anti-patterns.

## What gets caught

Running it on dev surfaced one real issue:

```
.github/workflows/upload_benchmark_result.yaml:24
  "github.event.issue.body" is potentially untrusted. avoid using it
  directly in inline scripts. instead, pass it through an environment
  variable.
```

Fixed in this PR by routing through an `ISSUE_BODY` env var. Same fix is also part of #291's bigger rewrite of that workflow, but landing it here keeps dev clean and means future workflow edits before #291 ships also benefit from the lint.

## Why now

Came out of the testing-strategy conversation on #291 — `actionlint` is Layer 1 of "how do we verify these workflows before firing them for real."

## Test plan

- [x] pre-commit hook runs locally: `uv run pre-commit run actionlint --all-files` → passes
- [ ] CI confirms the same on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)