### PR TITLE
DRY setup-python + pip-install into a composite action

### DIFF
--- a/.github/actions/install-meds-dev/action.yaml
+++ b/.github/actions/install-meds-dev/action.yaml
@@ -1,0 +1,30 @@
+name: Install MEDS-DEV
+description: >-
+  Set up Python and install MEDS-DEV via pip. Defaults to the PyPI release; pass a path or pip-spec
+  to install from somewhere else (e.g., the just-checked-out source tree in a regen-entities run).
+
+inputs:
+  python-version:
+    description: Python version to set up.
+    required: false
+    default: "3.11"
+  spec:
+    description: >-
+      pip install spec — package name, path, or version-pinned name. Defaults to the released
+      MEDS-DEV from PyPI ("meds-dev"). Pass "./main-branch" or similar to install from a local
+      checkout, or "meds-dev==0.1.0" to pin a version.
+    required: false
+    default: "meds-dev"
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install MEDS-DEV
+      shell: bash
+      env:
+        SPEC: ${{ inputs.spec }}
+      run: pip install "$SPEC"

--- a/.github/workflows/aggregate_benchmark_results.yaml
+++ b/.github/workflows/aggregate_benchmark_results.yaml
@@ -17,6 +17,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Default checkout (main) puts .github/actions/install-meds-dev at the
+      # workspace root for the composite action below.
+      - name: Checkout main (for composite actions)
+        uses: actions/checkout@v4
+
       - name: Check out the _results branch
         uses: actions/checkout@v4
         with:
@@ -29,13 +34,8 @@ jobs:
           ref: _web
           path: web-branch
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install MEDS-DEV from PyPI
-        run: pip install meds-dev
+      - name: Install MEDS-DEV
+        uses: ./.github/actions/install-meds-dev
 
       - name: Aggregate results
         run: |

--- a/.github/workflows/upload_benchmark_result.yaml
+++ b/.github/workflows/upload_benchmark_result.yaml
@@ -21,10 +21,18 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Default checkout (main) puts .github/actions/install-meds-dev at the
+      # workspace root so the composite action below can be referenced via
+      # `./.github/actions/...`. Without this, the workspace would only have
+      # the _results checkout (which doesn't carry .github/).
+      - name: Checkout main (for composite actions)
+        uses: actions/checkout@v4
+
       - name: Checkout _results branch
         uses: actions/checkout@v4
         with:
           ref: _results
+          path: results-branch
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract JSON from issue body
@@ -34,6 +42,7 @@ jobs:
           # Route the issue body through an env var to avoid shell injection
           # from arbitrary user content, then strip down to the ```json``` block.
           printf '%s' "$ISSUE_BODY" > issue_body.txt
+          # shellcheck disable=SC2016  # sed patterns are literal; single quotes are intentional.
           sed -n '/```json/,/```/p' issue_body.txt | sed '1d;$d' > "$GITHUB_WORKSPACE/result.json"
 
           if [[ ! -s "$GITHUB_WORKSPACE/result.json" ]]; then
@@ -44,13 +53,8 @@ jobs:
           echo "Extracted JSON:"
           cat "$GITHUB_WORKSPACE/result.json"
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install MEDS-DEV from PyPI
-        run: pip install meds-dev
+      - name: Install MEDS-DEV
+        uses: ./.github/actions/install-meds-dev
 
       - name: Validate result JSON
         run: meds-dev-validate-result result_fp="$GITHUB_WORKSPACE/result.json"
@@ -60,6 +64,7 @@ jobs:
           ISSUE_USER_LOGIN: ${{ github.event.issue.user.login }}
           ISSUE_USER_ID: ${{ github.event.issue.user.id }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+        working-directory: results-branch
         run: |
           mkdir -p "_results/${ISSUE_NUMBER}"
           mv "$GITHUB_WORKSPACE/result.json" "_results/${ISSUE_NUMBER}/result.json"


### PR DESCRIPTION
## Summary

DRY out the repeated setup-python + pip-install pattern across the workflow files into a single composite action. Targets `ci/inline-aggregate-results` (#291) since that PR introduces the two workflows this DRYs.

## What changes

- **New**: `.github/actions/install-meds-dev/action.yaml`. Sets up Python and runs `pip install $SPEC` where `SPEC` defaults to `meds-dev` but can be overridden:
  ```yaml
  - uses: ./.github/actions/install-meds-dev                      # PyPI release
  - uses: ./.github/actions/install-meds-dev
    with: { spec: "./main-branch" }                               # local checkout
  - uses: ./.github/actions/install-meds-dev
    with: { spec: "meds-dev==0.1.0", python-version: "3.12" }     # pinned version + py
  ```
- **`upload_benchmark_result.yaml`** and **`aggregate_benchmark_results.yaml`**: replace the inline setup-python + `pip install meds-dev` (6 lines) with `uses: ./.github/actions/install-meds-dev` (2 lines).
- **Workspace restructure**: local-action `uses: ./...` requires the action's source to be present in the workspace. Both workflows now do a default checkout (main) at the workspace root so `.github/actions/install-meds-dev/` is accessible; the branch checkouts (`_results`, `_web`) move into sibling `results-branch/` / `web-branch/` paths. The git commit step gets a `working-directory: results-branch` so pushes still go to the right tree.

## Why now

Came out of the "how do we test these workflows" conversation on #291. The repeated setup is also one of the things `actionlint` (just landed in #292) doesn't catch — it's a duplication smell, not a syntax error.

## What's NOT in this PR

`regenerate_entities.yaml` (introduced in #285) uses the same install pattern with `pip install ./main-branch`. It'll switch to the composite action in a follow-up commit on #285 after this lands and #285 rebases. Keeping that change out of this PR keeps the scope clean (this PR only touches files that already exist on #291's branch).

## Test plan

Workflow-only — no tests/code change. Once code-quality passes (actionlint is the relevant gate here), the PR can land.

- [ ] actionlint clean
- [ ] Manual smoke test of `aggregate_benchmark_results.yaml` via `workflow_dispatch` after merge to main + release (the `upload` workflow needs a real issue event so it gets exercised the next time someone submits a result)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
