### PR TITLE
Add meds-dev-process-submission CLI; collapse extract+validate

### DIFF
--- a/.github/workflows/upload_benchmark_result.yaml
+++ b/.github/workflows/upload_benchmark_result.yaml
@@ -19,29 +19,19 @@ jobs:
           ref: _results
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract JSON from issue body
-        id: extract_json
-        env:
-          ISSUE_BODY: ${{ github.event.issue.body }}
-        run: |
-          # Route through env var to avoid shell injection from arbitrary issue body content.
-          printf '%s' "$ISSUE_BODY" > issue_body.txt
-          # shellcheck disable=SC2016  # single-quotes are intentional — the sed patterns are literal.
-          sed -n '/```json/,/```/p' issue_body.txt | sed '1d;$d' > "$GITHUB_WORKSPACE/result.json"
-
-          if [[ ! -s "$GITHUB_WORKSPACE/result.json" ]]; then
-            echo "ERROR: No valid JSON found in the issue body."
-            exit 1
-          fi
-
-          echo "Extracted JSON:"
-          cat "$GITHUB_WORKSPACE/result.json"
-
       - name: Install MEDS-DEV package from PyPI
         run: pip install meds-dev
 
-      - name: Validate result JSON
-        run: meds-dev-validate-result result_fp="$GITHUB_WORKSPACE/result.json"
+      - name: Extract and validate result from issue body
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          # Single Python invocation: parses the ```json``` block out of the issue body,
+          # constructs a Result (which validates via Result.__post_init__), and writes the
+          # canonical (NaN-sanitized) JSON to disk.
+          printf '%s' "$ISSUE_BODY" | meds-dev-validate-result-from-issue \
+            --result_fp "$GITHUB_WORKSPACE/result.json" \
+            --do_overwrite
 
       - name: Commit result attributed to issue author
         if: success()

--- a/.github/workflows/upload_benchmark_result.yaml
+++ b/.github/workflows/upload_benchmark_result.yaml
@@ -24,12 +24,10 @@ jobs:
 
       - name: Extract and validate result from issue body
         env:
-          # The CLI reads the body from $ISSUE_BODY by default. Routing through an env var
-          # avoids shell injection — putting ${{ github.event.issue.body }} directly into a
-          # command line would let untrusted issue content escape and execute.
           ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
           meds-dev-process-submission \
+            --issue_body "$ISSUE_BODY" \
             --result_fp "$GITHUB_WORKSPACE/result.json" \
             --do_overwrite
 

--- a/.github/workflows/upload_benchmark_result.yaml
+++ b/.github/workflows/upload_benchmark_result.yaml
@@ -24,12 +24,12 @@ jobs:
 
       - name: Extract and validate result from issue body
         env:
+          # The CLI reads the body from $ISSUE_BODY by default. Routing through an env var
+          # avoids shell injection — putting ${{ github.event.issue.body }} directly into a
+          # command line would let untrusted issue content escape and execute.
           ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          # Single Python invocation: parses the ```json``` block out of the issue body,
-          # constructs a Result (which validates via Result.__post_init__), and writes the
-          # canonical (NaN-sanitized) JSON to disk.
-          printf '%s' "$ISSUE_BODY" | meds-dev-validate-result-from-issue \
+          meds-dev-process-submission \
             --result_fp "$GITHUB_WORKSPACE/result.json" \
             --do_overwrite
 

--- a/.gitignore
+++ b/.gitignore
@@ -357,3 +357,6 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,pycharm,visualstudiocode,windows
+
+# Claude Code local state
+.claude/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,9 +65,9 @@ meds-dev-model = "MEDS_DEV.models.__main__:main"
 meds-dev-evaluation = "MEDS_DEV.evaluation.__main__:main"
 meds-dev-pack-result = "MEDS_DEV.results.__main__:pack_result"
 meds-dev-validate-result = "MEDS_DEV.results.__main__:validate_result"
-meds-dev-validate-result-from-issue = "MEDS_DEV.results.__main__:validate_result_from_issue"
 meds-dev-collate-entities = "MEDS_DEV.web.collate_entities:main"
 meds-dev-aggregate-results = "MEDS_DEV.web.aggregate_results:main"
+meds-dev-process-submission = "MEDS_DEV.web.process_submission:main"
 
 [project.urls]
 Homepage = "https://github.com/Medical-Event-Data-Standard/MEDS-DEV"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ meds-dev-model = "MEDS_DEV.models.__main__:main"
 meds-dev-evaluation = "MEDS_DEV.evaluation.__main__:main"
 meds-dev-pack-result = "MEDS_DEV.results.__main__:pack_result"
 meds-dev-validate-result = "MEDS_DEV.results.__main__:validate_result"
+meds-dev-validate-result-from-issue = "MEDS_DEV.results.__main__:validate_result_from_issue"
 meds-dev-collate-entities = "MEDS_DEV.web.collate_entities:main"
 meds-dev-aggregate-results = "MEDS_DEV.web.aggregate_results:main"
 

--- a/src/MEDS_DEV/results/__init__.py
+++ b/src/MEDS_DEV/results/__init__.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import logging
 import math
+import re
 from importlib.resources import files
 from pathlib import Path
 from typing import Any
@@ -347,6 +348,38 @@ class Result:
             raise ValueError(f"Could not write result to {fp}") from e
 
     @classmethod
+    def from_dict(cls, as_dict: dict[str, Any]) -> "Result":
+        """Build a :class:`Result` from a plain dict, handling timestamp deserialization.
+
+        Use this when you already have the dict in hand (e.g., from parsing an issue body); see
+        :func:`extract_result_dict_from_issue_body`). For reading from a file, use :meth:`from_json`.
+
+        Examples:
+            Timestamps may be ISO-formatted strings; they get converted to ``datetime`` objects:
+
+            >>> Result.from_dict({
+            ...     "dataset": "MIMIC-IV", "task": "mortality/in_icu/first_24h",
+            ...     "model": "random_predictor", "timestamp": "2021-09-01T12:00:00",
+            ...     "result": {"acc": 0.5}, "version": "v",
+            ... }).timestamp
+            datetime.datetime(2021, 9, 1, 12, 0)
+
+            Already-aware ``datetime`` objects pass through:
+
+            >>> ts = datetime.datetime(2021, 9, 1, 12, 0, 0)
+            >>> Result.from_dict({
+            ...     "dataset": "d", "task": "t", "model": "m", "timestamp": ts,
+            ...     "result": {}, "version": "v",
+            ... }).timestamp is ts
+            True
+        """
+        as_dict = dict(as_dict)
+        ts = as_dict.get("timestamp")
+        if isinstance(ts, str):
+            as_dict["timestamp"] = datetime.datetime.fromisoformat(ts)
+        return cls(**as_dict)
+
+    @classmethod
     def from_json(cls, fp: Path | str) -> "Result":
         """Read a result from a JSON file."""
 
@@ -363,13 +396,83 @@ class Result:
         except Exception as e:
             raise ValueError(f"Could not read result from {fp}") from e
 
-        as_dict["timestamp"] = datetime.datetime.fromisoformat(as_dict["timestamp"])
+        return cls.from_dict(as_dict)
 
-        return cls(**as_dict)
+
+JSON_BLOCK_RE = re.compile(r"```json\s*\n(.*?)\n```", re.DOTALL)
+
+
+def extract_result_dict_from_issue_body(body: str) -> dict[str, Any]:
+    '''Extract the first fenced ```json ... ``` block from a GitHub issue body.
+
+    The benchmark-result submission template asks contributors to paste a JSON blob inside a fenced
+    code block. This helper returns the parsed dict so a caller (typically the upload workflow,
+    via :func:`MEDS_DEV.results.__main__.validate_result_from_issue`) can hand it to
+    :meth:`Result.from_dict` for validation.
+
+    Raises:
+        ValueError: If no fenced ```json``` block is found, or if the block isn't valid JSON.
+
+    Examples:
+        Happy path — the helper plucks out the dict regardless of surrounding prose:
+
+        >>> body = """Hi, here's my result:
+        ...
+        ... ```json
+        ... {"dataset": "MIMIC-IV", "result": {"acc": 0.5}}
+        ... ```
+        ...
+        ... Thanks!"""
+        >>> extract_result_dict_from_issue_body(body)
+        {'dataset': 'MIMIC-IV', 'result': {'acc': 0.5}}
+
+        Multi-line JSON inside the block works:
+
+        >>> body = """
+        ... ```json
+        ... {
+        ...   "dataset": "MIMIC-IV",
+        ...   "result": {"acc": 0.5}
+        ... }
+        ... ```
+        ... """
+        >>> extract_result_dict_from_issue_body(body)
+        {'dataset': 'MIMIC-IV', 'result': {'acc': 0.5}}
+
+        Missing block:
+
+        >>> extract_result_dict_from_issue_body("no fenced block here")
+        Traceback (most recent call last):
+            ...
+        ValueError: No ```json``` fenced block found in issue body.
+
+        Malformed JSON inside the block:
+
+        >>> extract_result_dict_from_issue_body("""
+        ... ```json
+        ... {not valid json
+        ... ```
+        ... """)
+        Traceback (most recent call last):
+            ...
+        ValueError: Issue body's ```json``` block is not valid JSON: ...
+    '''
+    match = JSON_BLOCK_RE.search(body)
+    if match is None:
+        raise ValueError("No ```json``` fenced block found in issue body.")
+    try:
+        return json.loads(match.group(1))
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Issue body's ```json``` block is not valid JSON: {e}") from e
 
 
 PACK_YAML = files("MEDS_DEV.configs") / "_package_result.yaml"
 VALIDATE_YAML = files("MEDS_DEV.configs") / "_validate_result.yaml"
 
 
-__all__ = ["PACK_YAML", "VALIDATE_YAML", "Result"]
+__all__ = [
+    "PACK_YAML",
+    "VALIDATE_YAML",
+    "Result",
+    "extract_result_dict_from_issue_body",
+]

--- a/src/MEDS_DEV/results/__init__.py
+++ b/src/MEDS_DEV/results/__init__.py
@@ -3,7 +3,6 @@ import datetime
 import json
 import logging
 import math
-import re
 from importlib.resources import files
 from pathlib import Path
 from typing import Any
@@ -351,8 +350,9 @@ class Result:
     def from_dict(cls, as_dict: dict[str, Any]) -> "Result":
         """Build a :class:`Result` from a plain dict, handling timestamp deserialization.
 
-        Use this when you already have the dict in hand (e.g., from parsing an issue body); see
-        :func:`extract_result_dict_from_issue_body`). For reading from a file, use :meth:`from_json`.
+        Use this when you already have the dict in hand (e.g., from parsing an issue body — see
+        :func:`MEDS_DEV.web.process_submission.extract_result_dict_from_issue_body`). For reading
+        from a file, use :meth:`from_json`.
 
         Examples:
             Timestamps may be ISO-formatted strings; they get converted to ``datetime`` objects:
@@ -399,80 +399,8 @@ class Result:
         return cls.from_dict(as_dict)
 
 
-JSON_BLOCK_RE = re.compile(r"```json\s*\n(.*?)\n```", re.DOTALL)
-
-
-def extract_result_dict_from_issue_body(body: str) -> dict[str, Any]:
-    '''Extract the first fenced ```json ... ``` block from a GitHub issue body.
-
-    The benchmark-result submission template asks contributors to paste a JSON blob inside a fenced
-    code block. This helper returns the parsed dict so a caller (typically the upload workflow,
-    via :func:`MEDS_DEV.results.__main__.validate_result_from_issue`) can hand it to
-    :meth:`Result.from_dict` for validation.
-
-    Raises:
-        ValueError: If no fenced ```json``` block is found, or if the block isn't valid JSON.
-
-    Examples:
-        Happy path — the helper plucks out the dict regardless of surrounding prose:
-
-        >>> body = """Hi, here's my result:
-        ...
-        ... ```json
-        ... {"dataset": "MIMIC-IV", "result": {"acc": 0.5}}
-        ... ```
-        ...
-        ... Thanks!"""
-        >>> extract_result_dict_from_issue_body(body)
-        {'dataset': 'MIMIC-IV', 'result': {'acc': 0.5}}
-
-        Multi-line JSON inside the block works:
-
-        >>> body = """
-        ... ```json
-        ... {
-        ...   "dataset": "MIMIC-IV",
-        ...   "result": {"acc": 0.5}
-        ... }
-        ... ```
-        ... """
-        >>> extract_result_dict_from_issue_body(body)
-        {'dataset': 'MIMIC-IV', 'result': {'acc': 0.5}}
-
-        Missing block:
-
-        >>> extract_result_dict_from_issue_body("no fenced block here")
-        Traceback (most recent call last):
-            ...
-        ValueError: No ```json``` fenced block found in issue body.
-
-        Malformed JSON inside the block:
-
-        >>> extract_result_dict_from_issue_body("""
-        ... ```json
-        ... {not valid json
-        ... ```
-        ... """)
-        Traceback (most recent call last):
-            ...
-        ValueError: Issue body's ```json``` block is not valid JSON: ...
-    '''
-    match = JSON_BLOCK_RE.search(body)
-    if match is None:
-        raise ValueError("No ```json``` fenced block found in issue body.")
-    try:
-        return json.loads(match.group(1))
-    except json.JSONDecodeError as e:
-        raise ValueError(f"Issue body's ```json``` block is not valid JSON: {e}") from e
-
-
 PACK_YAML = files("MEDS_DEV.configs") / "_package_result.yaml"
 VALIDATE_YAML = files("MEDS_DEV.configs") / "_validate_result.yaml"
 
 
-__all__ = [
-    "PACK_YAML",
-    "VALIDATE_YAML",
-    "Result",
-    "extract_result_dict_from_issue_body",
-]
+__all__ = ["PACK_YAML", "VALIDATE_YAML", "Result"]

--- a/src/MEDS_DEV/results/__main__.py
+++ b/src/MEDS_DEV/results/__main__.py
@@ -1,12 +1,14 @@
+import argparse
 import json
 import logging
+import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
 import hydra
 from omegaconf import DictConfig
 
-from . import PACK_YAML, VALIDATE_YAML, Result
+from . import PACK_YAML, VALIDATE_YAML, Result, extract_result_dict_from_issue_body
 
 logger = logging.getLogger(__name__)
 
@@ -56,3 +58,44 @@ def validate_result(cfg: DictConfig):
         Result.from_json(result_fp)
     except Exception as e:
         raise ValueError("Result should be packaged and decodable") from e
+
+
+def validate_result_from_issue() -> None:
+    """Extract a fenced ``\\`\\`\\`json`` block from a GitHub issue body, validate, and write to disk.
+
+    Used by ``upload_benchmark_result.yaml`` to collapse the previous extract-with-sed +
+    validate-from-file flow into a single Python invocation. Reads the issue body from stdin (or
+    from ``--issue_body_fp``), constructs a :class:`Result` (which validates via
+    ``Result.__post_init__``), and writes the canonical JSON via :meth:`Result.to_json` (which
+    sanitizes ``NaN`` / ``Inf`` to ``null``).
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Extract a ```json``` block from a GitHub issue body, validate it as a MEDS-DEV "
+            "result, and write the validated JSON to a file."
+        ),
+    )
+    parser.add_argument(
+        "--issue_body_fp",
+        type=Path,
+        default=None,
+        help="Path to a file containing the issue body text. If omitted, reads from stdin.",
+    )
+    parser.add_argument(
+        "--result_fp",
+        type=Path,
+        required=True,
+        help="Path to write the validated result JSON to.",
+    )
+    parser.add_argument(
+        "--do_overwrite",
+        action="store_true",
+        help="Overwrite the output file if it already exists.",
+    )
+    args = parser.parse_args()
+
+    body = args.issue_body_fp.read_text() if args.issue_body_fp else sys.stdin.read()
+    result_dict = extract_result_dict_from_issue_body(body)
+    result = Result.from_dict(result_dict)  # validates via __post_init__
+    result.to_json(args.result_fp, do_overwrite=args.do_overwrite)
+    logger.info(f"Wrote validated result to {args.result_fp}")

--- a/src/MEDS_DEV/results/__main__.py
+++ b/src/MEDS_DEV/results/__main__.py
@@ -1,14 +1,12 @@
-import argparse
 import json
 import logging
-import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
 import hydra
 from omegaconf import DictConfig
 
-from . import PACK_YAML, VALIDATE_YAML, Result, extract_result_dict_from_issue_body
+from . import PACK_YAML, VALIDATE_YAML, Result
 
 logger = logging.getLogger(__name__)
 
@@ -58,44 +56,3 @@ def validate_result(cfg: DictConfig):
         Result.from_json(result_fp)
     except Exception as e:
         raise ValueError("Result should be packaged and decodable") from e
-
-
-def validate_result_from_issue() -> None:
-    """Extract a fenced ``\\`\\`\\`json`` block from a GitHub issue body, validate, and write to disk.
-
-    Used by ``upload_benchmark_result.yaml`` to collapse the previous extract-with-sed +
-    validate-from-file flow into a single Python invocation. Reads the issue body from stdin (or
-    from ``--issue_body_fp``), constructs a :class:`Result` (which validates via
-    ``Result.__post_init__``), and writes the canonical JSON via :meth:`Result.to_json` (which
-    sanitizes ``NaN`` / ``Inf`` to ``null``).
-    """
-    parser = argparse.ArgumentParser(
-        description=(
-            "Extract a ```json``` block from a GitHub issue body, validate it as a MEDS-DEV "
-            "result, and write the validated JSON to a file."
-        ),
-    )
-    parser.add_argument(
-        "--issue_body_fp",
-        type=Path,
-        default=None,
-        help="Path to a file containing the issue body text. If omitted, reads from stdin.",
-    )
-    parser.add_argument(
-        "--result_fp",
-        type=Path,
-        required=True,
-        help="Path to write the validated result JSON to.",
-    )
-    parser.add_argument(
-        "--do_overwrite",
-        action="store_true",
-        help="Overwrite the output file if it already exists.",
-    )
-    args = parser.parse_args()
-
-    body = args.issue_body_fp.read_text() if args.issue_body_fp else sys.stdin.read()
-    result_dict = extract_result_dict_from_issue_body(body)
-    result = Result.from_dict(result_dict)  # validates via __post_init__
-    result.to_json(args.result_fp, do_overwrite=args.do_overwrite)
-    logger.info(f"Wrote validated result to {args.result_fp}")

--- a/src/MEDS_DEV/web/__init__.py
+++ b/src/MEDS_DEV/web/__init__.py
@@ -1,6 +1,12 @@
-"""Web tooling: collate entities and aggregate results for the MEDS-DEV website."""
+"""Web tooling: collate entities, aggregate results, and process result submissions."""
 
 from .aggregate_results import aggregate_results
 from .collate_entities import collate_entities
+from .process_submission import extract_result_dict_from_issue_body, process_submission
 
-__all__ = ["aggregate_results", "collate_entities"]
+__all__ = [
+    "aggregate_results",
+    "collate_entities",
+    "extract_result_dict_from_issue_body",
+    "process_submission",
+]

--- a/src/MEDS_DEV/web/process_submission.py
+++ b/src/MEDS_DEV/web/process_submission.py
@@ -1,0 +1,148 @@
+"""Process a GitHub issue benchmark-result submission.
+
+Drives the ``upload_benchmark_result.yaml`` workflow's per-submission step: read the issue body,
+extract the fenced ``\\`\\`\\`json`` block, validate it against :class:`MEDS_DEV.results.Result`, and
+write the canonical (NaN-sanitized) JSON to disk for the workflow to commit to the ``_results``
+branch.
+
+The CLI (``meds-dev-process-submission``) accepts the issue body via (in priority order):
+
+1. ``--issue_body_fp <path>`` — read from a file.
+2. ``$ISSUE_BODY`` environment variable (override the name with ``--issue_body_env_var``).
+3. Stdin — if neither of the above is provided.
+
+The GitHub Actions workflow uses option 2 because routing untrusted issue body content through an
+env var avoids shell-injection. Option 3 is for ad-hoc local invocation (``cat body.txt | meds-dev-
+process-submission ...``); option 1 is for tooling that already has the body on disk.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+from ..results import Result
+
+JSON_BLOCK_RE = re.compile(r"```json\s*\n(.*?)\n```", re.DOTALL)
+
+
+def extract_result_dict_from_issue_body(body: str) -> dict[str, Any]:
+    '''Extract the first fenced ```json ... ``` block from a GitHub issue body.
+
+    The benchmark-result submission template asks contributors to paste a JSON blob inside a fenced
+    code block. This helper returns the parsed dict so a caller can hand it to
+    :meth:`MEDS_DEV.results.Result.from_dict` for validation.
+
+    Raises:
+        ValueError: If no fenced ```json``` block is found, or if the block isn't valid JSON.
+
+    Examples:
+        Happy path — the helper plucks out the dict regardless of surrounding prose:
+
+        >>> body = """Hi, here's my result:
+        ...
+        ... ```json
+        ... {"dataset": "MIMIC-IV", "result": {"acc": 0.5}}
+        ... ```
+        ...
+        ... Thanks!"""
+        >>> extract_result_dict_from_issue_body(body)
+        {'dataset': 'MIMIC-IV', 'result': {'acc': 0.5}}
+
+        Multi-line JSON inside the block works:
+
+        >>> body = """
+        ... ```json
+        ... {
+        ...   "dataset": "MIMIC-IV",
+        ...   "result": {"acc": 0.5}
+        ... }
+        ... ```
+        ... """
+        >>> extract_result_dict_from_issue_body(body)
+        {'dataset': 'MIMIC-IV', 'result': {'acc': 0.5}}
+
+        Missing block:
+
+        >>> extract_result_dict_from_issue_body("no fenced block here")
+        Traceback (most recent call last):
+            ...
+        ValueError: No ```json``` fenced block found in issue body.
+
+        Malformed JSON inside the block:
+
+        >>> extract_result_dict_from_issue_body("""
+        ... ```json
+        ... {not valid json
+        ... ```
+        ... """)
+        Traceback (most recent call last):
+            ...
+        ValueError: Issue body's ```json``` block is not valid JSON: ...
+    '''
+    match = JSON_BLOCK_RE.search(body)
+    if match is None:
+        raise ValueError("No ```json``` fenced block found in issue body.")
+    try:
+        return json.loads(match.group(1))
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Issue body's ```json``` block is not valid JSON: {e}") from e
+
+
+def process_submission(body: str, result_fp: Path, do_overwrite: bool = False) -> None:
+    """Extract a result from an issue body, validate it, and write the canonical JSON to disk."""
+    result_dict = extract_result_dict_from_issue_body(body)
+    result = Result.from_dict(result_dict)  # validates via __post_init__
+    result.to_json(result_fp, do_overwrite=do_overwrite)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Extract a ```json``` block from a GitHub issue body, validate it as a MEDS-DEV "
+            "result, and write the validated JSON to a file."
+        ),
+    )
+    parser.add_argument(
+        "--issue_body_fp",
+        type=Path,
+        default=None,
+        help="Path to a file containing the issue body text. Takes priority over env-var / stdin.",
+    )
+    parser.add_argument(
+        "--issue_body_env_var",
+        default="ISSUE_BODY",
+        help=(
+            "Name of the environment variable to read the issue body from when --issue_body_fp is "
+            "not set. Defaults to ISSUE_BODY (the GHA convention)."
+        ),
+    )
+    parser.add_argument(
+        "--result_fp",
+        type=Path,
+        required=True,
+        help="Path to write the validated result JSON to.",
+    )
+    parser.add_argument(
+        "--do_overwrite",
+        action="store_true",
+        help="Overwrite the output file if it already exists.",
+    )
+    args = parser.parse_args()
+
+    if args.issue_body_fp is not None:
+        body = args.issue_body_fp.read_text()
+    elif (env_val := os.environ.get(args.issue_body_env_var)) is not None:
+        body = env_val
+    elif not sys.stdin.isatty():
+        body = sys.stdin.read()
+    else:
+        parser.error(
+            f"No issue body provided. Pass --issue_body_fp, set ${args.issue_body_env_var}, "
+            "or pipe the body on stdin."
+        )
+
+    process_submission(body, args.result_fp, do_overwrite=args.do_overwrite)

--- a/src/MEDS_DEV/web/process_submission.py
+++ b/src/MEDS_DEV/web/process_submission.py
@@ -5,20 +5,16 @@ extract the fenced ``\\`\\`\\`json`` block, validate it against :class:`MEDS_DEV
 write the canonical (NaN-sanitized) JSON to disk for the workflow to commit to the ``_results``
 branch.
 
-The CLI (``meds-dev-process-submission``) accepts the issue body via (in priority order):
+The CLI (``meds-dev-process-submission``) accepts the issue body via, in priority order:
 
-1. ``--issue_body_fp <path>`` — read from a file.
-2. ``$ISSUE_BODY`` environment variable (override the name with ``--issue_body_env_var``).
-3. Stdin — if neither of the above is provided.
-
-The GitHub Actions workflow uses option 2 because routing untrusted issue body content through an
-env var avoids shell-injection. Option 3 is for ad-hoc local invocation (``cat body.txt | meds-dev-
-process-submission ...``); option 1 is for tooling that already has the body on disk.
+1. ``--issue_body <text>`` — the body as a direct string argument. Use this from CI (the workflow
+    expands ``$ISSUE_BODY`` into the argument under safe quoting).
+2. ``--issue_body_fp <path>`` — read from a file.
+3. Stdin — for ad-hoc local invocation, e.g., ``cat body.txt | meds-dev-process-submission ...``.
 """
 
 import argparse
 import json
-import os
 import re
 import sys
 from pathlib import Path
@@ -106,19 +102,17 @@ def main() -> None:
             "result, and write the validated JSON to a file."
         ),
     )
-    parser.add_argument(
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument(
+        "--issue_body",
+        default=None,
+        help="The issue body text, passed directly. Takes priority over --issue_body_fp / stdin.",
+    )
+    source.add_argument(
         "--issue_body_fp",
         type=Path,
         default=None,
-        help="Path to a file containing the issue body text. Takes priority over env-var / stdin.",
-    )
-    parser.add_argument(
-        "--issue_body_env_var",
-        default="ISSUE_BODY",
-        help=(
-            "Name of the environment variable to read the issue body from when --issue_body_fp is "
-            "not set. Defaults to ISSUE_BODY (the GHA convention)."
-        ),
+        help="Path to a file containing the issue body text.",
     )
     parser.add_argument(
         "--result_fp",
@@ -133,16 +127,13 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    if args.issue_body_fp is not None:
+    if args.issue_body is not None:
+        body = args.issue_body
+    elif args.issue_body_fp is not None:
         body = args.issue_body_fp.read_text()
-    elif (env_val := os.environ.get(args.issue_body_env_var)) is not None:
-        body = env_val
     elif not sys.stdin.isatty():
         body = sys.stdin.read()
     else:
-        parser.error(
-            f"No issue body provided. Pass --issue_body_fp, set ${args.issue_body_env_var}, "
-            "or pipe the body on stdin."
-        )
+        parser.error("No issue body provided. Pass --issue_body, --issue_body_fp, or pipe on stdin.")
 
     process_submission(body, args.result_fp, do_overwrite=args.do_overwrite)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -94,3 +94,48 @@ def test_aggregate_results_cli() -> None:
             "43": {"model": "b", "score": 0.85},
             "44": {"model": "c", "score": 0.78},
         }
+
+
+def test_process_submission_cli() -> None:
+    """``meds-dev-process-submission`` extracts the ```json``` block, validates, and writes the canonical
+    (NaN-sanitized, strict) JSON."""
+    body = """Hi! Here's my result.
+
+```json
+{
+  "dataset": "MIMIC-IV",
+  "task": "mortality/in_icu/first_24h",
+  "model": "random_predictor",
+  "timestamp": "2025-01-01T00:00:00",
+  "result": {"acc": 0.85, "auc": NaN},
+  "version": "v0.1.0"
+}
+```
+
+Thanks!"""
+
+    with yaml_disk({".gitkeep": ""}) as d:
+        out = d / "result.json"
+        result = subprocess.run(
+            [
+                "meds-dev-process-submission",
+                "--issue_body",
+                body,
+                "--result_fp",
+                str(out),
+                "--do_overwrite",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0
+        written = json.loads(out.read_text())
+        assert written["dataset"] == "MIMIC-IV"
+        assert written["task"] == "mortality/in_icu/first_24h"
+        assert written["model"] == "random_predictor"
+        # NaN is sanitized to None on the way through Result.to_json:
+        assert written["result"] == {"acc": 0.85, "auc": None}
+        # On-disk JSON is strict (no bare NaN tokens):
+        assert "NaN" not in out.read_text()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -8,8 +8,37 @@ them with shell setup.
 
 import json
 import subprocess
+import sys
 
+import pytest
 from yaml_to_disk import yaml_disk
+
+ISSUE_BODY = """Hi! Here's my result.
+
+```json
+{
+  "dataset": "MIMIC-IV",
+  "task": "mortality/in_icu/first_24h",
+  "model": "random_predictor",
+  "timestamp": "2025-01-01T00:00:00",
+  "result": {"acc": 0.85, "auc": NaN},
+  "version": "v0.1.0"
+}
+```
+
+Thanks!"""
+
+
+def _assert_canonical_result_written(out_fp) -> None:
+    """Shared assertions for the three body-source variants below."""
+    written = json.loads(out_fp.read_text())
+    assert written["dataset"] == "MIMIC-IV"
+    assert written["task"] == "mortality/in_icu/first_24h"
+    assert written["model"] == "random_predictor"
+    # NaN is sanitized to None on the way through Result.to_json:
+    assert written["result"] == {"acc": 0.85, "auc": None}
+    # On-disk JSON is strict (no bare NaN tokens):
+    assert "NaN" not in out_fp.read_text()
 
 
 def test_collate_entities_cli() -> None:
@@ -96,31 +125,15 @@ def test_aggregate_results_cli() -> None:
         }
 
 
-def test_process_submission_cli() -> None:
-    """``meds-dev-process-submission`` extracts the ```json``` block, validates, and writes the canonical
-    (NaN-sanitized, strict) JSON."""
-    body = """Hi! Here's my result.
-
-```json
-{
-  "dataset": "MIMIC-IV",
-  "task": "mortality/in_icu/first_24h",
-  "model": "random_predictor",
-  "timestamp": "2025-01-01T00:00:00",
-  "result": {"acc": 0.85, "auc": NaN},
-  "version": "v0.1.0"
-}
-```
-
-Thanks!"""
-
+def test_process_submission_cli_issue_body_arg() -> None:
+    """``--issue_body`` (direct string): extract → validate → canonical JSON."""
     with yaml_disk({".gitkeep": ""}) as d:
         out = d / "result.json"
-        result = subprocess.run(
+        subprocess.run(
             [
                 "meds-dev-process-submission",
                 "--issue_body",
-                body,
+                ISSUE_BODY,
                 "--result_fp",
                 str(out),
                 "--do_overwrite",
@@ -129,13 +142,50 @@ Thanks!"""
             capture_output=True,
             text=True,
         )
+        _assert_canonical_result_written(out)
 
-        assert result.returncode == 0
-        written = json.loads(out.read_text())
-        assert written["dataset"] == "MIMIC-IV"
-        assert written["task"] == "mortality/in_icu/first_24h"
-        assert written["model"] == "random_predictor"
-        # NaN is sanitized to None on the way through Result.to_json:
-        assert written["result"] == {"acc": 0.85, "auc": None}
-        # On-disk JSON is strict (no bare NaN tokens):
-        assert "NaN" not in out.read_text()
+
+def test_process_submission_cli_issue_body_fp() -> None:
+    """``--issue_body_fp``: read body from a file, then extract → validate → canonical JSON."""
+    with yaml_disk({"body.md": ISSUE_BODY}) as d:
+        out = d / "result.json"
+        subprocess.run(
+            [
+                "meds-dev-process-submission",
+                "--issue_body_fp",
+                str(d / "body.md"),
+                "--result_fp",
+                str(out),
+                "--do_overwrite",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        _assert_canonical_result_written(out)
+
+
+def test_process_submission_cli_stdin() -> None:
+    """Stdin fallback: with no body flag, the CLI reads the body from stdin when it is piped."""
+    with yaml_disk({".gitkeep": ""}) as d:
+        out = d / "result.json"
+        subprocess.run(
+            ["meds-dev-process-submission", "--result_fp", str(out), "--do_overwrite"],
+            input=ISSUE_BODY,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        _assert_canonical_result_written(out)
+
+
+def test_process_submission_main_errors_without_body(monkeypatch, tmp_path) -> None:
+    """No body flag + stdin attached to a tty → ``parser.error`` and ``SystemExit``."""
+    from MEDS_DEV.web.process_submission import main
+
+    monkeypatch.setattr(
+        sys, "argv", ["meds-dev-process-submission", "--result_fp", str(tmp_path / "out.json")]
+    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    with pytest.raises(SystemExit):
+        main()


### PR DESCRIPTION
## Summary

Replaces the brittle sed-based JSON extraction + separate validate step in `upload_benchmark_result.yaml` with a single CLI invocation. The fragile shell logic (no-fenced-block detection, malformed-JSON detection, NaN sanitization) becomes doctested Python, plus a subprocess test on the real CLI entry point.

## What changes

**New module `MEDS_DEV.web.process_submission`:**

- `extract_result_dict_from_issue_body(body: str) -> dict` — regex-based extractor for the fenced ` ```json ``` ` block in a GitHub issue body. Doctested for happy path, multi-line JSON, missing block, and malformed JSON.
- `process_submission(body, result_fp, do_overwrite)` — extract, validate via `Result.from_dict`, and write the canonical JSON.

**`Result.from_dict` (new classmethod in `MEDS_DEV.results`):**

Handles timestamp deserialization (ISO string → `datetime`) and validates via `__post_init__`. `Result.from_json` is refactored to use it.

**New CLI: `meds-dev-process-submission`**

```bash
meds-dev-process-submission \
    --issue_body "$ISSUE_BODY" \
    --result_fp "$GITHUB_WORKSPACE/result.json" \
    --do_overwrite
```

Body source resolves, in priority order, via a mutually-exclusive group:

1. `--issue_body <text>` — direct string. Used by CI (the workflow expands `$ISSUE_BODY` into the argument under safe shell quoting, so injection safety is preserved without making the CLI implicitly depend on a specific env var name).
2. `--issue_body_fp <path>` — read from a file.
3. Stdin — for ad-hoc local invocation (e.g., `cat body.txt | meds-dev-process-submission ...`).

**Workflow simplification:**

The upload workflow's separate "Extract JSON from issue body" (sed pipeline + null check) and "Validate result JSON" steps both fold into the single CLI call above.

## What's preserved

- `meds-dev-validate-result` (the file-in CLI) is unchanged. Local validation by a contributor checking their result before submission keeps working.

## Test plan

- [x] Doctests for `extract_result_dict_from_issue_body` and `Result.from_dict`
- [x] `test_process_submission_cli` — subprocess test that pipes a realistic issue body through the real entry point, asserts the written JSON matches expectations, and verifies NaN is sanitized to `null` on disk
- [x] Full fast suite passes locally (50 tests)

## Related

- Targets `dev`; downstream PRs (#291, #285, #287) will pick up these changes via `git merge origin/dev`.
- Came out of the testing-strategy conversation on #291: extracting fragile bash into testable Python.
- Sibling to #292 (actionlint) which catches the static issues; this one closes the dynamic-behavior testing gap for the issue-body parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
