### PR TITLE
Add CEHR-XGPT model (mimiciv + omop variants)

### DIFF
--- a/src/MEDS_DEV/models/cehrxgpt/README.md
+++ b/src/MEDS_DEV/models/cehrxgpt/README.md
@@ -1,0 +1,4 @@
+# CEHRGPT
+
+CEHRGPT is a multi-task foundation model for structured electronic health records (EHR) data that supports three capabilities: feature representation, zero-shot prediction, and synthetic data generation.
+For detailed documentation, please refer to [https://github.com/knatarajan-lab/cehrgpt](https://github.com/knatarajan-lab/cehrgpt).

--- a/src/MEDS_DEV/models/cehrxgpt/mimiciv/README.md
+++ b/src/MEDS_DEV/models/cehrxgpt/mimiciv/README.md
@@ -1,0 +1,7 @@
+# CEHR-XGPT MIMIC-IV
+
+This repository contains a CEHR-XGPT model customized for the **MIMIC-IV** dataset.
+It is tailored to MIMIC-IV because the data pipeline includes [logic](https://github.com/cumc-dbmi/cehrbert/blob/main/src/cehrbert/data_generators/hf_data_generator/meds_to_cehrbert_conversion_rules/meds_to_cehrbert_micmic4.py) specific to this source, including:
+
+- Extracting and structuring visits with clear boundaries.
+- Parsing numeric values stored within text fields for proper representation.

--- a/src/MEDS_DEV/models/cehrxgpt/mimiciv/model.yaml
+++ b/src/MEDS_DEV/models/cehrxgpt/mimiciv/model.yaml
@@ -1,0 +1,91 @@
+metadata:
+  description: >-
+    CEHR-XGPT: A Scalable Multi-Task Foundation Model for Electronic Health Records.
+  links:
+    - https://arxiv.org/abs/2509.03643
+  contacts:
+    - name: "Chao Pang"
+      github_username: "ChaoPang"
+    - name: "Jiheum Park"
+      github_username: "jp4147"
+commands:
+  unsupervised:
+    train: |-
+      mkdir -p "{output_dir}/cehrgpt_pretrained/meds_reader"
+      mkdir -p "{output_dir}/cehrgpt_pretrained/dataset_prepared"
+      meds_reader_convert "{dataset_dir}" "{output_dir}/cehrgpt_pretrained/meds_reader" --num_threads 8
+
+      echo "Attempting to install flash-attn (optional)..."
+      pip install flash-attn || echo "Warning: flash-attn installation failed. Continuing without it."
+
+      # Set model configuration based on demo mode
+      if [ "{demo}" = "True" ] || [ "{demo}" = "true" ]; then
+          export HIDDEN_SIZE=256
+          export NUM_LAYERS=4
+          export MAX_POS_EMB=128
+          export MAX_TOKENS=512
+          export NUM_EPOCHS=5
+          export DATALOADER_WORKERS=2
+          export PREFETCH_FACTOR=2
+      else
+          export HIDDEN_SIZE=768
+          export NUM_LAYERS=14
+          export MAX_POS_EMB=8192
+          export MAX_TOKENS=16384
+          export NUM_EPOCHS=50
+          export DATALOADER_WORKERS=8
+          export PREFETCH_FACTOR=8
+      fi
+
+      export CUDA_VISIBLE_DEVICES="\${CUDA_VISIBLE_DEVICES:-0}"; python -u -m cehrgpt.runners.hf_cehrgpt_pretrain_runner \
+      --model_name_or_path "{output_dir}/cehrgpt_pretrained" \
+      --tokenizer_name_or_path "{output_dir}/cehrgpt_pretrained" \
+      --output_dir "{output_dir}/cehrgpt_pretrained" \
+      --data_folder "{output_dir}/cehrgpt_pretrained/meds_reader" \
+      --tokenized_dataset_name "full_tokenized_dataset" \
+      --dataset_prepared_path {output_dir}/cehrgpt_pretrained/dataset_prepared \
+      --do_train true --seed 42  \
+      --dataloader_num_workers $DATALOADER_WORKERS \
+      --dataloader_prefetch_factor $PREFETCH_FACTOR \
+      --hidden_size $HIDDEN_SIZE \
+      --num_hidden_layers $NUM_LAYERS \
+      --max_position_embeddings $MAX_POS_EMB \
+      --evaluation_strategy epoch --save_strategy epoch \
+      --sample_packing --max_tokens_per_batch $MAX_TOKENS \
+      --warmup_ratio 0.01 --weight_decay 0.01 \
+      --num_train_epochs $NUM_EPOCHS \
+      --learning_rate 0.0001 \
+      --use_early_stopping --early_stopping_threshold 0.001 \
+      --load_best_model_at_end \
+      --is_data_in_meds --inpatient_att_function_type day \
+      --att_function_type day --include_inpatient_hour_token \
+      --include_auxiliary_token --include_demographic_prompt \
+      --meds_to_cehrbert_conversion_type MedsToBertMimic4 \
+      --report_to "none"
+
+  supervised:
+    train: |-
+      mkdir -p "{output_dir}"
+      export CUDA_VISIBLE_DEVICES="\${CUDA_VISIBLE_DEVICES:-0}"; python -u -m cehrgpt.tools.linear_prob.compute_cehrgpt_features \
+      --model_name_or_path {model_initialization_dir} \
+      --tokenizer_name_or_path {model_initialization_dir} \
+      --tokenized_full_dataset_path "{model_initialization_dir}/dataset_prepared/full_tokenized_dataset" \
+      --dataset_prepared_path {model_initialization_dir}/cehrgpt_pretrained/dataset_prepared \
+      --data_folder {model_initialization_dir}/cehrgpt_pretrained/meds_reader \
+      --cohort_folder {labels_dir} \
+      --output_dir {output_dir} \
+      --seed 42 \
+      --dataloader_num_workers 8 --dataloader_prefetch_factor 8 \
+      --sample_packing --max_tokens_per_batch 16384 \
+      --is_data_in_meds --inpatient_att_function_type day \
+      --att_function_type day --include_inpatient_hour_token \
+      --include_auxiliary_token --include_demographic_prompt \
+      --meds_to_cehrbert_conversion_type MedsToBertMimic4
+
+    predict: |-
+      mkdir -p "{output_dir}"
+      python -u -m cehrgpt.tools.linear_prob.train_with_cehrgpt_features \
+        --features_data_dir {model_initialization_dir} \
+        --output_dir {output_dir}
+
+      cp {output_dir}/logistic/test_predictions/predictions.parquet {output_dir}/predictions.parquet

--- a/src/MEDS_DEV/models/cehrxgpt/mimiciv/requirements.txt
+++ b/src/MEDS_DEV/models/cehrxgpt/mimiciv/requirements.txt
@@ -1,0 +1,3 @@
+meds_reader==0.1.9
+cehrgpt==0.1.6.post4
+tf-keras

--- a/src/MEDS_DEV/models/cehrxgpt/omop/README.md
+++ b/src/MEDS_DEV/models/cehrxgpt/omop/README.md
@@ -1,0 +1,4 @@
+# CEHR-XGPT OMOP
+
+This repository contains a CEHR-XGPT model customized for the **OMOP** dataset.
+It is tailored to OMOP because the data pipeline includes [logic](https://github.com/cumc-dbmi/cehrbert/blob/main/src/cehrbert/data_generators/hf_data_generator/meds_to_cehrbert_conversion_rules/meds_to_cehrbert_omop.py) specific to this source, e.g. extracting and structuring visits with clear boundaries.

--- a/src/MEDS_DEV/models/cehrxgpt/omop/model.yaml
+++ b/src/MEDS_DEV/models/cehrxgpt/omop/model.yaml
@@ -1,0 +1,92 @@
+metadata:
+  description: >-
+    CEHR-XGPT: A Scalable Multi-Task Foundation Model for Electronic Health Records.
+  links:
+    - https://arxiv.org/abs/2509.03643
+  contacts:
+    - name: "Chao Pang"
+      github_username: "ChaoPang"
+    - name: "Jiheum Park"
+      github_username: "jp4147"
+commands:
+  unsupervised:
+    train: |-
+      mkdir -p "{output_dir}/cehrgpt_pretrained/meds_reader"
+      mkdir -p "{output_dir}/cehrgpt_pretrained/dataset_prepared"
+      meds_reader_convert "{dataset_dir}" "{output_dir}/cehrgpt_pretrained/meds_reader" --num_threads 8
+
+      echo "Attempting to install flash-attn (optional)..."
+      pip install flash-attn || echo "Warning: flash-attn installation failed. Continuing without it."
+
+      # Set model configuration based on demo mode
+      if [ "{demo}" = "True" ] || [ "{demo}" = "true" ]; then
+          export HIDDEN_SIZE=256
+          export NUM_LAYERS=4
+          export MAX_POS_EMB=128
+          export MAX_TOKENS=512
+          export NUM_EPOCHS=5
+          export DATALOADER_WORKERS=2
+          export PREFETCH_FACTOR=2
+      else
+          export HIDDEN_SIZE=768
+          export NUM_LAYERS=14
+          export MAX_POS_EMB=8192
+          export MAX_TOKENS=16384
+          export NUM_EPOCHS=50
+          export DATALOADER_WORKERS=8
+          export PREFETCH_FACTOR=8
+      fi
+
+      export CUDA_VISIBLE_DEVICES="\${CUDA_VISIBLE_DEVICES:-0}"; python -u -m cehrgpt.runners.hf_cehrgpt_pretrain_runner \
+      --model_name_or_path "{output_dir}/cehrgpt_pretrained" \
+      --tokenizer_name_or_path "{output_dir}/cehrgpt_pretrained" \
+      --output_dir "{output_dir}/cehrgpt_pretrained" \
+      --data_folder "{output_dir}/cehrgpt_pretrained/meds_reader" \
+      --tokenized_dataset_name "full_tokenized_dataset" \
+      --dataset_prepared_path {output_dir}/cehrgpt_pretrained/dataset_prepared \
+      --do_train true --seed 42  \
+      --dataloader_num_workers $DATALOADER_WORKERS \
+      --dataloader_prefetch_factor $PREFETCH_FACTOR \
+      --hidden_size $HIDDEN_SIZE \
+      --num_hidden_layers $NUM_LAYERS \
+      --max_position_embeddings $MAX_POS_EMB \
+      --evaluation_strategy epoch --save_strategy epoch \
+      --sample_packing --max_tokens_per_batch $MAX_TOKENS \
+      --warmup_ratio 0.01 --weight_decay 0.01 \
+      --num_train_epochs $NUM_EPOCHS \
+      --learning_rate 0.0001 \
+      --use_early_stopping --early_stopping_threshold 0.001 \
+      --load_best_model_at_end \
+      --is_data_in_meds --inpatient_att_function_type day \
+      --att_function_type day --include_inpatient_hour_token \
+      --include_auxiliary_token --include_demographic_prompt \
+      --meds_to_cehrbert_conversion_type MedsToCehrbertOMOP \
+      --report_to "none"
+
+  supervised:
+    train: |-
+      mkdir -p "{output_dir}"
+      export CUDA_VISIBLE_DEVICES="\${CUDA_VISIBLE_DEVICES:-0}"; python -u -m cehrgpt.tools.linear_prob.compute_cehrgpt_features \
+      --model_name_or_path {model_initialization_dir} \
+      --tokenizer_name_or_path {model_initialization_dir} \
+      --tokenized_full_dataset_path "{model_initialization_dir}/dataset_prepared/full_tokenized_dataset" \
+      --dataset_prepared_path {model_initialization_dir}/cehrgpt_pretrained/dataset_prepared \
+      --data_folder {model_initialization_dir}/cehrgpt_pretrained/meds_reader \
+      --cohort_folder {labels_dir} \
+      --output_dir {output_dir} \
+      --seed 42 \
+      --dataloader_num_workers 8 --dataloader_prefetch_factor 8 \
+      --sample_packing --max_tokens_per_batch 16384 \
+      --is_data_in_meds --inpatient_att_function_type day \
+      --att_function_type day --include_inpatient_hour_token \
+      --include_auxiliary_token --include_demographic_prompt \
+      --disconnect_problem_list_events \
+      --meds_to_cehrbert_conversion_type MedsToCehrbertOMOP
+
+    predict: |-
+      mkdir -p "{output_dir}"
+      python -u -m cehrgpt.tools.linear_prob.train_with_cehrgpt_features \
+        --features_data_dir {model_initialization_dir} \
+        --output_dir {output_dir}
+
+      cp {output_dir}/logistic/test_predictions/predictions.parquet {output_dir}/predictions.parquet

--- a/src/MEDS_DEV/models/cehrxgpt/omop/requirements.txt
+++ b/src/MEDS_DEV/models/cehrxgpt/omop/requirements.txt
@@ -1,0 +1,3 @@
+meds_reader==0.1.9
+cehrgpt==0.1.6.post4
+tf-keras

--- a/src/MEDS_DEV/models/cehrxgpt/refs.bib
+++ b/src/MEDS_DEV/models/cehrxgpt/refs.bib
@@ -1,0 +1,10 @@
+@article{Pang2025,
+   abstract = {Electronic Health Records (EHRs) provide a rich, longitudinal view of patient health and hold significant potential for advancing clinical decision support, risk prediction, and data-driven healthcare research. However, most artificial intelligence (AI) models for EHRs are designed for narrow, single-purpose tasks, limiting their generalizability and utility in real-world settings. Here, we present CEHR-XGPT, a general-purpose foundation model for EHR data that unifies three essential capabilities - feature representation, zero-shot prediction, and synthetic data generation - within a single architecture. To support temporal reasoning over clinical sequences, CEHR-XGPT incorporates a novel time-token-based learning framework that explicitly encodes patients' dynamic timelines into the model structure. CEHR-XGPT demonstrates strong performance across all three tasks and generalizes effectively to external datasets through vocabulary expansion and fine-tuning. Its versatility enables rapid model development, cohort discovery, and patient outcome forecasting without the need for task-specific retraining.},
+   author = {Chao Pang and Jiheum Park and Xinzhuo Jiang and Nishanth Parameshwar Pavinkurve and Krishna S. Kalluri and Shalmali Joshi and Noémie Elhadad and Karthik Natarajan},
+   isbn = {2509.03643v2},
+   keywords = {cs.AI,cs.LG},
+   month = {9},
+   title = {CEHR-XGPT: A Scalable Multi-Task Foundation Model for Electronic Health Records},
+   url = {https://arxiv.org/pdf/2509.03643},
+   year = {2025}
+}


### PR DESCRIPTION
## Summary

Replicates the model additions from #248 on top of current dev. The upstream branch is too far behind dev to merge directly (it reverts the web-tooling, CI tiers, CLAUDE.md, uv.lock, etc.). This PR keeps only the model content and rebases it onto dev as a single commit.

## What's added

`src/MEDS_DEV/models/cehrxgpt/`:

```
├── README.md
├── refs.bib
├── mimiciv/{README.md, model.yaml, requirements.txt}
└── omop/{README.md, model.yaml, requirements.txt}
```

Each variant defines:

- **`unsupervised: train`** — cehrgpt pre-training via `cehrgpt.runners.hf_cehrgpt_pretrain_runner`, with a `{demo}`-mode-gated config switch (smaller model + fewer epochs in demo mode).
- **`supervised: train`** — linear-probe feature computation (`cehrgpt.tools.linear_prob.compute_cehrgpt_features`) on top of the pretrained foundation model.
- **`supervised: predict`** — logistic regression on the cached features (`cehrgpt.tools.linear_prob.train_with_cehrgpt_features`), writing `predictions.parquet`.

The `mimiciv` and `omop` variants differ only in the `--meds_to_cehrbert_conversion_type` flag (`MedsToBertMimic4` vs `MedsToCehrbertOMOP`) and one extra arg on the OMOP supervised train.

Dropped the empty `__init__.py` files the upstream branch carried — other model dirs in dev don't have them.

## Fix applied during local review

- **Hardcoded `CUDA_VISIBLE_DEVICES=\"0\"`** — softened to `CUDA_VISIBLE_DEVICES=\"\${CUDA_VISIBLE_DEVICES:-0}\"` (escaped `\\\$` so OmegaConf doesn't try to interpolate it; bash sees the proper `\${VAR:-default}` at run time). Defaults to GPU 0 when unset, respects an externally-set value if present. Allows CPU-only test runs and multi-GPU users to override without editing the model.yaml.

## Open items needing maintainer / contributor input

Draft because these aren't fixed yet:

1. **Runtime `pip install flash-attn` in `unsupervised: train`** — bracketed by `|| echo \"Warning: ...\"` so it's explicitly optional. Worth deciding whether to add to `requirements.txt` (failure surfaces at install time, recoverable) or keep as runtime-optional.
2. **`--evaluation_strategy epoch`** — renamed to `--eval_strategy` in HF transformers ≥ 4.46. With `cehrgpt==0.1.6.post4` pinned this probably works today, but ride the version constraints carefully.
3. **Quoting inconsistency** — same command block has both `\"{output_dir}/foo\"` and `{output_dir}/foo`. Safe with current test paths, easy to break.
4. **`omop/model.yaml supervised: train`** has `--disconnect_problem_list_events` while `mimiciv/model.yaml` doesn't — likely intentional but worth a one-line confirmation.
5. **Naming drift** — directory is `cehrxgpt`, package is `cehrgpt`, paper is \"CEHR-XGPT\". Existing convention; not a blocker.

## Test plan

- [x] Pre-commit passes.
- [x] Full fast test suite passes (53 tests, including registry validation for the new model).
- [ ] Integration tests for cehrxgpt require GPU + real MIMIC-IV / OMOP data.

## Supersedes / refs

- Supersedes #248 (`add_cehrgpt` branch by @ChaoPang is too stale to merge directly).
- Co-authored with @ChaoPang, @jp4147 (per the original branch contributors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)