### PR TITLE
Add CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,58 @@
+# Contributors Guide
+
+Thank you for your interest in contributing to this project. The following sections outline the expectations
+for contributors.
+
+## Good Practice
+
+- Discuss large changes with the maintainers before significant work begins.
+- Keep commits focused and provide clear commit messages.
+- Include tests for new functionality and bug fixes.
+- Ensure documentation is updated for user-facing changes.
+
+## Installing the Project for Development
+
+This project uses [`uv`](https://docs.astral.sh/uv/) for environment management. To set up the project for
+development, simply clone the repository, then sync the uv environment, activate it, and install the pre-commit
+environment:
+
+```bash
+uv sync
+source .venv/bin/activate # Not strictly necessary, but ensures if you don't use uv things still work.
+uv run pre-commit install
+```
+
+## Documentation Standards
+
+Documentation should be written using
+[Google style docstrings](https://www.sphinx-doc.org/en/master/usage/extensions/example_google.html).
+API validation can be tested directly inside these docstrings via doctests; this behavior is encouraged.
+
+Helpers like `yaml_disk` and `print_directory` can be made available by
+installing the helpers [`yaml_to_disk`](https://github.com/mmcdermott/yaml_to_disk) (which allows you to
+populate temporary directories via a yaml snippet) and
+[`pretty-print-directory`](https://github.com/mmcdermott/pretty-print-directory) (which allows you to print a
+directory structure for doctest prettification) in the development environment. Once installed, these packages
+_automatically register in the doctest namespace within pytest_, so you can use them directly in doctests
+without needing to import them.
+
+A global `conftest.py` further populates the namespace using `pytest`'s `doctest_namespace` fixture, meaning
+you rarely need explicit imports in doctests.
+
+## Running Checks
+
+Pre-commit should run automatically upon commit (if you have installed the hooks above). You can also run it
+directly via:
+
+```bash
+uv run pre-commit run --all-files
+```
+
+You can also run the tests (including doctests):
+
+```bash
+uv run pytest -v
+```
+
+Tests and pre-commit checks are run as part of the continuous integration process, so any failures will prevent
+pull requests from being merged.


### PR DESCRIPTION
## Summary

Adds a `CONTRIBUTORS.md` to give new contributors a top-level "how to get started" entry point. Replicates the doc from #249 on top of current dev (the upstream branch is too stale to merge directly).

Content covers: good-practice expectations, `uv`-based environment setup, doctest-first documentation standards (with pointers to `yaml_to_disk` and `pretty-print-directory` helpers), and how to run pre-commit / tests locally.

## Known gaps (not blockers, follow-ups OK)

The doc is templated from a generic project-template; a few MEDS-DEV-specific additions would help:

- Mention `CLAUDE.md` as the place to look for operational details.
- The `uv run pytest -v` instruction omits that the full suite builds datasets/venvs — newcomers should default to `-m \"not integration\"` for fast feedback and read CLAUDE.md for the full picture.
- No section on the most common contributor workflow (adding a new dataset / task / model — the registry conventions aren't obvious from the file).
- No mention of PR-issue linking (`Closes #N`).
- No mention of the issue-based result-submission flow (now a contributor-facing thing).

Happy to do a follow-up PR adding these once this lands.

## Test plan

- [x] Pre-commit passes (mdformat normalizes the file in place).

## Supersedes / refs

- Supersedes #249 (`add_contributors_docs` branch by @rvandewater).
- Co-authored with @rvandewater.

🤖 Generated with [Claude Code](https://claude.com/claude-code)