### PR TITLE
Make `build_demo` optional, skip demo-less datasets in tests

### DIFF
--- a/src/MEDS_DEV/datasets/__main__.py
+++ b/src/MEDS_DEV/datasets/__main__.py
@@ -33,7 +33,15 @@ def main(cfg: DictConfig):
         logger.info(f"Output directory {output_dir} already exists and is marked as done.")
         return
 
-    build_cmd = commands["build_demo"] if cfg.demo else commands["build_full"]
+    if cfg.demo:
+        if "build_demo" not in commands:
+            raise ValueError(
+                f"Dataset {cfg.dataset} does not declare a build_demo command — `demo=True` is not "
+                f"supported for this dataset. Build the full dataset instead (drop the `demo` arg)."
+            )
+        build_cmd = commands["build_demo"]
+    else:
+        build_cmd = commands["build_full"]
 
     with temp_env(cfg, requirements) as (build_temp_dir, env):
         build_cmd = build_cmd.format(output_dir=cfg.output_dir, temp_dir=str(build_temp_dir.resolve()))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -325,6 +325,11 @@ def get_opts(config, opt: str) -> list[str]:
     if isinstance(out, dict):
         out = list(out.keys())
 
+    if opt == "dataset":
+        # Drop datasets that don't declare a build_demo command — they can't be exercised by the
+        # demo-mode integration tests below.
+        out = [name for name in out if "build_demo" in (DATASETS[name].get("commands") or {})]
+
     return out
 
 

--- a/tests/test_registry_validation.py
+++ b/tests/test_registry_validation.py
@@ -31,7 +31,9 @@ def test_all_datasets_have_commands():
     for name, dataset in DATASETS.items():
         commands = dataset.get("commands")
         assert commands is not None, f"Dataset {name} missing commands"
-        assert "build_demo" in commands, f"Dataset {name} missing build_demo command"
+        # build_full is required; build_demo is optional (its absence means the dataset has no demo recipe,
+        # and the dataset will be skipped from the integration-test demo lane — see tests/conftest.py).
+        assert "build_full" in commands, f"Dataset {name} missing build_full command"
 
 
 def test_all_datasets_have_predicates():


### PR DESCRIPTION
## Summary

Prerequisite for the per-dataset registration PRs (#305 AUMCdb, #306 EHRShot, #307 HIRID, #308 INSPIRE, #309 NWICU, #310 SICdb, #311 eICU). Most of those datasets' upstream extractors don't ship a publicly-installable demo, and the existing registry validation requires every dataset to declare a `build_demo` command.

Switches the convention to: **a dataset has a demo iff its `commands` declare `build_demo`**. The absence of the key is itself the signal — no separate metadata field, no `echo "..."` stubs, and no two-sources-of-truth ambiguity.

## What changes

Three small edits, no behavior change for datasets that already declare `build_demo` (e.g., MIMIC-IV):

- **`test_all_datasets_have_commands`** now requires `build_full` (which every dataset still needs) and allows missing `build_demo`.
- **`tests/conftest.py`** drops datasets without `build_demo` from the integration test matrix, so a per-dataset CI lane for one collects zero parametrized tests and passes cleanly rather than trying to build data the dataset can't produce.
- **`src/MEDS_DEV/datasets/__main__.py`** raises a clear `ValueError` when called with `demo=True` against a dataset that doesn't declare a `build_demo` command (instead of the previous `KeyError`).

No `dataset.yaml` files change here — those changes ship with the sister per-dataset PRs that depend on this one.

## Test plan

- [x] Pre-commit passes.
- [x] Fast test suite passes (53 tests, including the existing registry validation against MIMIC-IV).
- N/A: no new doctests; the logic is exercised by registry validation + the per-dataset integration lanes.

## Refs

- Carved out of the closed bundled PR #299.
- Each of #305 – #311 retargets to `dev` once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
