### PR TITLE
Address PR #279 review: harden CI gate, add safeguards, fix docs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -291,25 +291,68 @@ jobs:
           echo "**Scope reason**: ${{ needs.determine-scope.outputs.reason }}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Check required jobs
+        env:
+          DETERMINE_SCOPE_RESULT: ${{ needs.determine-scope.result }}
+          FAST_CHECKS_RESULT: ${{ needs.fast-checks.result }}
+          DATASET_LANE_RESULT: ${{ needs.dataset-lane.result }}
+          TASK_LANE_RESULT: ${{ needs.task-lane.result }}
+          MODEL_LANE_RESULT: ${{ needs.model-lane.result }}
+          FULL_INTEGRATION_RESULT: ${{ needs.full-integration.result }}
+          RUN_FULL: ${{ needs.determine-scope.outputs.run_full }}
+          DOCS_ONLY: ${{ needs.determine-scope.outputs.docs_only }}
+          CHANGED_DATASETS: ${{ needs.determine-scope.outputs.changed_datasets }}
+          CHANGED_TASKS: ${{ needs.determine-scope.outputs.changed_tasks }}
+          CHANGED_MODELS: ${{ needs.determine-scope.outputs.changed_models }}
         run: |
+          set -uo pipefail
           FAILED=""
-          if [[ "${{ needs.fast-checks.result }}" == "failure" ]]; then
-            FAILED="$FAILED fast-checks"
+
+          # determine-scope must SUCCEED: every downstream gate reads its outputs, so if it
+          # failed/was cancelled the lanes were skipped for the wrong reason and a green summary
+          # would be a false pass.
+          if [[ "$DETERMINE_SCOPE_RESULT" != "success" ]]; then
+            FAILED="$FAILED determine-scope(=$DETERMINE_SCOPE_RESULT)"
           fi
-          if [[ "${{ needs.dataset-lane.result }}" == "failure" ]]; then
-            FAILED="$FAILED dataset-lane"
+
+          # fast-checks always runs; require it to SUCCEED. Checking "!= failure" would let a
+          # cancelled or skipped fast-checks slip through as a pass.
+          if [[ "$FAST_CHECKS_RESULT" != "success" ]]; then
+            FAILED="$FAILED fast-checks(=$FAST_CHECKS_RESULT)"
           fi
-          if [[ "${{ needs.task-lane.result }}" == "failure" ]]; then
-            FAILED="$FAILED task-lane"
+
+          # For an integration lane, a "skipped" result is only acceptable when the scope did not
+          # select it. If the scope expected the lane to run, it must have succeeded; anything else
+          # (skipped/cancelled/failure) means the gate and the job disagreed.
+          check_lane() {
+            local name="$1" result="$2" expected="$3"
+            if [[ "$expected" == "true" ]]; then
+              if [[ "$result" != "success" ]]; then
+                FAILED="$FAILED $name(expected-run,=$result)"
+              fi
+            else
+              if [[ "$result" != "skipped" ]]; then
+                FAILED="$FAILED $name(expected-skip,=$result)"
+              fi
+            fi
+          }
+
+          # Reconstruct each lane's gating condition from the scope outputs (see the lane `if:`s).
+          full_expected="false"; ds_expected="false"; tk_expected="false"; md_expected="false"
+          if [[ "$RUN_FULL" == "true" ]]; then
+            full_expected="true"
+          elif [[ "$DOCS_ONLY" != "true" ]]; then
+            if [[ "$CHANGED_DATASETS" != "[]" ]]; then ds_expected="true"; fi
+            if [[ "$CHANGED_TASKS" != "[]" ]]; then tk_expected="true"; fi
+            if [[ "$CHANGED_MODELS" != "[]" ]]; then md_expected="true"; fi
           fi
-          if [[ "${{ needs.model-lane.result }}" == "failure" ]]; then
-            FAILED="$FAILED model-lane"
-          fi
-          if [[ "${{ needs.full-integration.result }}" == "failure" ]]; then
-            FAILED="$FAILED full-integration"
-          fi
+
+          check_lane dataset-lane "$DATASET_LANE_RESULT" "$ds_expected"
+          check_lane task-lane "$TASK_LANE_RESULT" "$tk_expected"
+          check_lane model-lane "$MODEL_LANE_RESULT" "$md_expected"
+          check_lane full-integration "$FULL_INTEGRATION_RESULT" "$full_expected"
+
           if [[ -n "$FAILED" ]]; then
-            echo "Failed jobs:$FAILED"
+            echo "Required-job check failed:$FAILED"
             exit 1
           fi
-          echo "All required jobs passed or were skipped."
+          echo "All required jobs completed as expected (scope: run_full=$RUN_FULL docs_only=$DOCS_ONLY)."

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,13 +13,20 @@ for contributors.
 ## Installing the Project for Development
 
 This project uses [`uv`](https://docs.astral.sh/uv/) for environment management. To set up the project for
-development, simply clone the repository, then sync the uv environment, activate it, and install the pre-commit
-environment:
+development, clone the repository, then sync the uv environment and install the pre-commit hook:
 
 ```bash
-uv sync
-source .venv/bin/activate # Not strictly necessary, but ensures if you don't use uv things still work.
-uv run pre-commit install
+uv sync                   # Creates .venv and installs the project (editable) plus the dev/test extras.
+uv run pre-commit install # Installs the Git pre-commit hook so checks run automatically on commit.
+```
+
+`uv sync` installs `MEDS-DEV` in editable mode, so source edits take effect without reinstalling.
+Prefixing commands with `uv run` (e.g. `uv run pytest`) runs them inside the project environment
+without activating it. Activating the environment is optional; if you prefer to drop the `uv run`
+prefix, activate it first:
+
+```bash
+source .venv/bin/activate # Optional — lets you run `pytest`/`pre-commit` directly, without `uv run`.
 ```
 
 ## Documentation Standards
@@ -48,10 +55,22 @@ directly via:
 uv run pre-commit run --all-files
 ```
 
-You can also run the tests (including doctests):
+You can also run the tests. The suite is split into a fast lane and a full integration lane via the
+`integration` pytest marker, and doctests are opt-in through `--doctest-modules` (they are **not**
+run by a bare `pytest` invocation).
+
+For quick feedback while developing, run the fast lane — doctests plus unit/registry tests, no
+dataset builds or model virtual environments:
 
 ```bash
-uv run pytest -v
+uv run pytest --doctest-modules -m "not integration" -x
+```
+
+To run the full suite, including the end-to-end integration tests that build datasets, create model
+environments, and run train/predict/evaluate:
+
+```bash
+uv run pytest -v -s --doctest-modules
 ```
 
 Tests and pre-commit checks are run as part of the continuous integration process, so any failures will prevent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ omit = ["*/models/cehrbert/*"]
 [tool.pytest.ini_options]
 addopts = [
   "--color=yes",
+  "--strict-markers",
+  "--strict-config",
 ]
 doctest_optionflags = "ELLIPSIS NORMALIZE_WHITESPACE"
 markers = [

--- a/src/MEDS_DEV/datasets/__main__.py
+++ b/src/MEDS_DEV/datasets/__main__.py
@@ -11,6 +11,48 @@ from . import CFG_YAML, DATASETS
 logger = logging.getLogger(__name__)
 
 
+def _select_build_command(dataset: str, commands: dict, demo: bool) -> str:
+    """Return the build command for the requested build mode.
+
+    ``build_full`` is always required; ``build_demo`` is optional (a dataset may have no demo
+    recipe). Requesting ``demo=True`` for a dataset that does not declare ``build_demo`` is an error.
+
+    Args:
+        dataset: The dataset name, used only for the error message.
+        commands: The dataset's ``commands`` mapping (must contain ``build_full``; may contain
+            ``build_demo``).
+        demo: Whether the demo build was requested.
+
+    Returns:
+        The selected build command string.
+
+    Raises:
+        ValueError: If ``demo`` is ``True`` but ``commands`` has no ``build_demo`` entry.
+
+    Examples:
+        >>> cmds = {"build_full": "full-cmd", "build_demo": "demo-cmd"}
+        >>> _select_build_command("D", cmds, demo=False)
+        'full-cmd'
+        >>> _select_build_command("D", cmds, demo=True)
+        'demo-cmd'
+        >>> _select_build_command("D", {"build_full": "full-cmd"}, demo=False)
+        'full-cmd'
+        >>> _select_build_command("D", {"build_full": "full-cmd"}, demo=True)
+        Traceback (most recent call last):
+            ...
+        ValueError: Dataset D does not declare a build_demo command — `demo=True` is not supported
+        for this dataset. Build the full dataset instead (drop the `demo` arg).
+    """
+    if demo:
+        if "build_demo" not in commands:
+            raise ValueError(
+                f"Dataset {dataset} does not declare a build_demo command — `demo=True` is not "
+                f"supported for this dataset. Build the full dataset instead (drop the `demo` arg)."
+            )
+        return commands["build_demo"]
+    return commands["build_full"]
+
+
 @hydra.main(version_base=None, config_path=str(CFG_YAML.parent), config_name=CFG_YAML.stem)
 def main(cfg: DictConfig):
     if cfg.dataset not in DATASETS:
@@ -33,15 +75,7 @@ def main(cfg: DictConfig):
         logger.info(f"Output directory {output_dir} already exists and is marked as done.")
         return
 
-    if cfg.demo:
-        if "build_demo" not in commands:
-            raise ValueError(
-                f"Dataset {cfg.dataset} does not declare a build_demo command — `demo=True` is not "
-                f"supported for this dataset. Build the full dataset instead (drop the `demo` arg)."
-            )
-        build_cmd = commands["build_demo"]
-    else:
-        build_cmd = commands["build_full"]
+    build_cmd = _select_build_command(cfg.dataset, commands, cfg.demo)
 
     with temp_env(cfg, requirements) as (build_temp_dir, env):
         build_cmd = build_cmd.format(output_dir=cfg.output_dir, temp_dir=str(build_temp_dir.resolve()))

--- a/src/MEDS_DEV/results/__init__.py
+++ b/src/MEDS_DEV/results/__init__.py
@@ -34,6 +34,13 @@ def _sanitize_nan_inf(obj: Any) -> Any:
         {'nested': {'deep': {'v': None}}}
         >>> _sanitize_nan_inf([float("nan"), {"a": float("inf")}])
         [None, {'a': None}]
+
+    Tuples are recursed into as well (and preserved as tuples). In practice ``self.result`` is
+    always JSON-decoded, so tuples never appear there, but this keeps the helper correct for any
+    caller that hands it a tuple:
+
+        >>> _sanitize_nan_inf((1.0, float("nan"), (float("inf"), 2.0)))
+        (1.0, None, (None, 2.0))
     """
     if isinstance(obj, float):
         if math.isnan(obj) or math.isinf(obj):
@@ -43,6 +50,8 @@ def _sanitize_nan_inf(obj: Any) -> Any:
         return {k: _sanitize_nan_inf(v) for k, v in obj.items()}
     if isinstance(obj, list):
         return [_sanitize_nan_inf(v) for v in obj]
+    if isinstance(obj, tuple):
+        return tuple(_sanitize_nan_inf(v) for v in obj)
     return obj
 
 

--- a/tests/test_0_datasets.py
+++ b/tests/test_0_datasets.py
@@ -1,10 +1,14 @@
+from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import Mock
 
 import pytest
 from meds_testing_helpers.dataset import MEDSDataset
+from omegaconf import OmegaConf
 
 from MEDS_DEV import DATASETS
+from MEDS_DEV.datasets import __main__ as datasets_main
 from tests.utils import NAME_AND_DIR, run_command
 
 
@@ -36,3 +40,45 @@ def test_datasets_configured(demo_dataset: NAME_AND_DIR):
         MEDSDataset(root_dir=demo_dataset_dir)
     except Exception as e:
         raise AssertionError(f"Failed to validate dataset {dataset_name} from {demo_dataset_dir}") from e
+
+
+def test_select_build_command():
+    commands = {"build_full": "full-cmd", "build_demo": "demo-cmd"}
+
+    assert datasets_main._select_build_command("D", commands, demo=False) == "full-cmd"
+    assert datasets_main._select_build_command("D", commands, demo=True) == "demo-cmd"
+
+    with pytest.raises(ValueError, match="does not declare a build_demo command"):
+        datasets_main._select_build_command("D", {"build_full": "full-cmd"}, demo=True)
+
+
+def test_main_selects_build_command(monkeypatch, tmp_path):
+    output_dir = tmp_path / "output"
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    run_in_env = Mock()
+
+    @contextmanager
+    def fake_temp_env(cfg, requirements):
+        yield build_dir, "env"
+
+    monkeypatch.setattr(
+        datasets_main,
+        "DATASETS",
+        {"D": {"commands": {"build_full": "build {output_dir}"}, "requirements": []}},
+    )
+    monkeypatch.setattr(datasets_main, "temp_env", fake_temp_env)
+    monkeypatch.setattr(datasets_main, "run_in_env", run_in_env)
+
+    cfg = OmegaConf.create(
+        {"dataset": "D", "demo": False, "output_dir": str(output_dir), "do_overwrite": False}
+    )
+    datasets_main.main.__wrapped__(cfg)
+
+    run_in_env.assert_called_once_with(
+        f"build {output_dir}",
+        str(output_dir),
+        env="env",
+        do_overwrite=False,
+        cwd=build_dir,
+    )

--- a/tests/test_4_result_packaging.py
+++ b/tests/test_4_result_packaging.py
@@ -7,7 +7,15 @@ from pathlib import Path
 import pytest
 
 from MEDS_DEV import __version__ as MEDS_DEV_version
-from MEDS_DEV.results import Result
+from MEDS_DEV.results import Result, _sanitize_nan_inf
+
+
+def test_sanitize_nan_inf_preserves_tuples():
+    result = _sanitize_nan_inf((1.0, float("nan"), (float("inf"), 2.0)))
+
+    assert result == (1.0, None, (None, 2.0))
+    assert isinstance(result, tuple)
+    assert isinstance(result[2], tuple)
 
 
 def test_validate_result_error():

--- a/tests/test_select_test_scope.py
+++ b/tests/test_select_test_scope.py
@@ -24,96 +24,88 @@ select_test_scope = _load_module()
 classify_changes = select_test_scope.classify_changes
 
 
-# Each case: (label, changed_files, expected-subset-of-classification).
-# Only the keys present in `expected` are asserted, so cases stay focused on the decision they probe.
+# Each case contains the complete set of fields that control workflow execution. ``reason`` is
+# intentionally checked separately because it is diagnostic text, not an input to lane selection.
+def expected_scope(*, run_full=False, docs_only=False, datasets=(), tasks=(), models=()):
+    return {
+        "run_full": run_full,
+        "docs_only": docs_only,
+        "changed_datasets": list(datasets),
+        "changed_tasks": list(tasks),
+        "changed_models": list(models),
+    }
+
+
 CASES = [
     (
         "docs_only_top_level",
         ["README.md", "CONTRIBUTORS.md", "CLAUDE.md"],
-        {
-            "run_full": False,
-            "docs_only": True,
-            "changed_datasets": [],
-            "changed_tasks": [],
-            "changed_models": [],
-        },
+        expected_scope(docs_only=True),
     ),
     (
         "docs_only_nested_readme",
         ["src/MEDS_DEV/datasets/MIMIC-IV/README.md"],
-        {"run_full": False, "docs_only": True, "changed_datasets": []},
+        expected_scope(docs_only=True),
     ),
     (
         "single_dataset",
         ["src/MEDS_DEV/datasets/MIMIC-IV/dataset.yaml"],
-        {
-            "run_full": False,
-            "docs_only": False,
-            "changed_datasets": ["MIMIC-IV"],
-            "changed_tasks": [],
-            "changed_models": [],
-        },
+        expected_scope(datasets=("MIMIC-IV",)),
     ),
     (
         "single_task_keeps_relative_name",
         ["src/MEDS_DEV/tasks/mortality/in_icu/first_24h.yaml"],
-        {"run_full": False, "changed_tasks": ["mortality/in_icu/first_24h"], "changed_datasets": []},
+        expected_scope(tasks=("mortality/in_icu/first_24h",)),
     ),
     (
         "single_model",
         ["src/MEDS_DEV/models/random_predictor/model.yaml"],
-        {"run_full": False, "changed_models": ["random_predictor"], "changed_datasets": []},
+        expected_scope(models=("random_predictor",)),
     ),
     (
         "core_file_promotes_to_full",
         ["src/MEDS_DEV/utils.py"],
-        {"run_full": True, "docs_only": False},
+        expected_scope(run_full=True),
     ),
     (
         "conftest_promotes_to_full",
         ["tests/conftest.py"],
-        {"run_full": True},
+        expected_scope(run_full=True),
     ),
     (
         "workflow_change_promotes_to_full",
         [".github/workflows/tests.yaml"],
-        {"run_full": True},
+        expected_scope(run_full=True),
     ),
     (
         "dataset_test_file_promotes_to_full",
         ["tests/test_0_datasets.py"],
-        {"run_full": True},
+        expected_scope(run_full=True),
     ),
     (
         "registry_test_stays_fast",
         ["tests/test_registry_validation.py"],
-        {
-            "run_full": False,
-            "docs_only": False,
-            "changed_datasets": [],
-            "changed_tasks": [],
-            "changed_models": [],
-        },
+        expected_scope(),
     ),
     (
         "unknown_file_promotes_to_full",
         ["some_top_level_thing.py"],
-        {"run_full": True},
+        expected_scope(run_full=True),
     ),
     (
         "empty_diff_runs_full",
         [],
-        {"run_full": True, "docs_only": False},
+        expected_scope(run_full=True),
     ),
     (
         "docs_plus_code_is_not_docs_only",
         ["README.md", "src/MEDS_DEV/datasets/MIMIC-IV/dataset.yaml"],
-        {"run_full": False, "docs_only": False, "changed_datasets": ["MIMIC-IV"]},
+        expected_scope(datasets=("MIMIC-IV",)),
     ),
     (
         "core_override_wins_over_component",
         ["src/MEDS_DEV/datasets/MIMIC-IV/dataset.yaml", "src/MEDS_DEV/utils.py"],
-        {"run_full": True},
+        expected_scope(run_full=True, datasets=("MIMIC-IV",)),
     ),
     (
         "multiple_datasets_sorted_and_deduped",
@@ -122,7 +114,7 @@ CASES = [
             "src/MEDS_DEV/datasets/MIMIC-IV/predicates.yaml",
             "src/MEDS_DEV/datasets/eICU/dataset.yaml",
         ],
-        {"run_full": False, "changed_datasets": ["MIMIC-IV", "eICU"]},
+        expected_scope(datasets=("MIMIC-IV", "eICU")),
     ),
 ]
 
@@ -130,8 +122,9 @@ CASES = [
 @pytest.mark.parametrize("label,changed_files,expected", CASES, ids=[c[0] for c in CASES])
 def test_classify_changes(label, changed_files, expected):
     result = classify_changes(changed_files)
-    for key, want in expected.items():
-        assert result[key] == want, f"[{label}] key {key!r}: got {result[key]!r}, want {want!r}"
+    actual = {key: value for key, value in result.items() if key != "reason"}
+    assert actual == expected, f"[{label}] got {actual!r}, want {expected!r}"
+    assert isinstance(result["reason"], str) and result["reason"]
 
 
 def test_classify_changes_returns_all_keys():

--- a/tests/test_select_test_scope.py
+++ b/tests/test_select_test_scope.py
@@ -1,0 +1,146 @@
+"""Table-driven unit tests for the CI scope-selection logic.
+
+``.github/scripts/select_test_scope.py`` decides which CI test lanes run for a given diff. It gates
+the entire test workflow, so its `classify_changes` routine is worth exercising directly (it is not
+importable as a normal package, so we load it from its path).
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "select_test_scope.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("select_test_scope", _SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+select_test_scope = _load_module()
+classify_changes = select_test_scope.classify_changes
+
+
+# Each case: (label, changed_files, expected-subset-of-classification).
+# Only the keys present in `expected` are asserted, so cases stay focused on the decision they probe.
+CASES = [
+    (
+        "docs_only_top_level",
+        ["README.md", "CONTRIBUTORS.md", "CLAUDE.md"],
+        {
+            "run_full": False,
+            "docs_only": True,
+            "changed_datasets": [],
+            "changed_tasks": [],
+            "changed_models": [],
+        },
+    ),
+    (
+        "docs_only_nested_readme",
+        ["src/MEDS_DEV/datasets/MIMIC-IV/README.md"],
+        {"run_full": False, "docs_only": True, "changed_datasets": []},
+    ),
+    (
+        "single_dataset",
+        ["src/MEDS_DEV/datasets/MIMIC-IV/dataset.yaml"],
+        {
+            "run_full": False,
+            "docs_only": False,
+            "changed_datasets": ["MIMIC-IV"],
+            "changed_tasks": [],
+            "changed_models": [],
+        },
+    ),
+    (
+        "single_task_keeps_relative_name",
+        ["src/MEDS_DEV/tasks/mortality/in_icu/first_24h.yaml"],
+        {"run_full": False, "changed_tasks": ["mortality/in_icu/first_24h"], "changed_datasets": []},
+    ),
+    (
+        "single_model",
+        ["src/MEDS_DEV/models/random_predictor/model.yaml"],
+        {"run_full": False, "changed_models": ["random_predictor"], "changed_datasets": []},
+    ),
+    (
+        "core_file_promotes_to_full",
+        ["src/MEDS_DEV/utils.py"],
+        {"run_full": True, "docs_only": False},
+    ),
+    (
+        "conftest_promotes_to_full",
+        ["tests/conftest.py"],
+        {"run_full": True},
+    ),
+    (
+        "workflow_change_promotes_to_full",
+        [".github/workflows/tests.yaml"],
+        {"run_full": True},
+    ),
+    (
+        "dataset_test_file_promotes_to_full",
+        ["tests/test_0_datasets.py"],
+        {"run_full": True},
+    ),
+    (
+        "registry_test_stays_fast",
+        ["tests/test_registry_validation.py"],
+        {
+            "run_full": False,
+            "docs_only": False,
+            "changed_datasets": [],
+            "changed_tasks": [],
+            "changed_models": [],
+        },
+    ),
+    (
+        "unknown_file_promotes_to_full",
+        ["some_top_level_thing.py"],
+        {"run_full": True},
+    ),
+    (
+        "empty_diff_runs_full",
+        [],
+        {"run_full": True, "docs_only": False},
+    ),
+    (
+        "docs_plus_code_is_not_docs_only",
+        ["README.md", "src/MEDS_DEV/datasets/MIMIC-IV/dataset.yaml"],
+        {"run_full": False, "docs_only": False, "changed_datasets": ["MIMIC-IV"]},
+    ),
+    (
+        "core_override_wins_over_component",
+        ["src/MEDS_DEV/datasets/MIMIC-IV/dataset.yaml", "src/MEDS_DEV/utils.py"],
+        {"run_full": True},
+    ),
+    (
+        "multiple_datasets_sorted_and_deduped",
+        [
+            "src/MEDS_DEV/datasets/MIMIC-IV/dataset.yaml",
+            "src/MEDS_DEV/datasets/MIMIC-IV/predicates.yaml",
+            "src/MEDS_DEV/datasets/eICU/dataset.yaml",
+        ],
+        {"run_full": False, "changed_datasets": ["MIMIC-IV", "eICU"]},
+    ),
+]
+
+
+@pytest.mark.parametrize("label,changed_files,expected", CASES, ids=[c[0] for c in CASES])
+def test_classify_changes(label, changed_files, expected):
+    result = classify_changes(changed_files)
+    for key, want in expected.items():
+        assert result[key] == want, f"[{label}] key {key!r}: got {result[key]!r}, want {want!r}"
+
+
+def test_classify_changes_returns_all_keys():
+    result = classify_changes(["README.md"])
+    assert set(result) == {
+        "run_full",
+        "docs_only",
+        "changed_datasets",
+        "changed_tasks",
+        "changed_models",
+        "reason",
+    }


### PR DESCRIPTION
Follow-ups to @florian6973's review on the dev→main release PR (#279). Each point below maps to a bullet in that review.

## CI required-check gate (point 2 — "required CI check can pass without tests completing")
Rewrites the `Check required jobs` step in the `run_tests_ubuntu` summary job so a green summary actually means the expected tests ran:

- **Require `determine-scope` to succeed** — every downstream gate reads its outputs; if it failed/cancelled, the lanes were skipped for the wrong reason.
- **Require `fast-checks` to succeed** (`== 'success'`, not the old `!= 'failure'`) — a cancelled/skipped `fast-checks` is no longer a pass.
- **Reject cancelled / unexpectedly-skipped jobs** and **allow skipped integration lanes only when the scope expected them to be skipped** — each lane is checked against the reconstructed scope condition: expected-to-run ⇒ must be `success`; not-selected ⇒ must be `skipped`.

Verified locally against 10 scenarios (docs-only all-skipped, full-run success, full-integration skipped/cancelled under a full scope, determine-scope failure, fast-checks cancelled, dataset lane selected-and-succeeds / selected-but-skipped / selected-but-failed, unselected lane that failed).

## Cheap safeguards (point 3)
- `--strict-markers` **and** `--strict-config` added to `[tool.pytest.ini_options].addopts`.
- **Table-driven tests** for `classify_changes()` in `tests/test_select_test_scope.py` (15 cases: docs-only, per-component scoping, core/test-file promotion, empty diff, dedup/sort).
- **`demo=True` / no `build_demo` error path**: extracted `_select_build_command()` in `datasets/__main__.py` with doctests covering both build modes and the error — these are the two lines codecov flagged as uncovered.
- **`_sanitize_nan_inf()` handles tuples** (recurses, preserves tuple type) with a doctest. Defensive: `self.result` is always JSON-decoded in practice, so tuples don't occur there — noted as such in the docstring.

## Contributor docs (point 5)
- Corrects the now-inaccurate `uv run pytest -v` "including doctests" claim — this release removed `--doctest-modules` from `addopts`, so doctests are opt-in.
- Presents the **fast** (`-m "not integration"`) and **full** test commands separately.
- Documents `uv sync` (editable install), optional `.venv` activation, and the `pre-commit install` hook.

Points 1 (PR description) and 4 (release ordering / workflow-event coverage) are handled directly on #279 rather than in code.

Refs #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)