### PR TITLE
Allow dataset builds to reuse downloaded raw source data

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ meds-dev-dataset dataset=$DATASET_NAME output_dir=$DATASET_DIR
 where `DATASET_NAME` is the name of the dataset you want to build and `OUTPUT_DIR` is the directory where you
 want to store the final, MEDS-formatted dataset.
 
+If you have already downloaded the source dataset, point the builder at it to avoid downloading it again:
+
+```bash
+meds-dev-dataset dataset=$DATASET_NAME output_dir=$DATASET_DIR raw_input_dir=/path/to/downloaded/data
+```
+
+This works for recipes that use the `{raw_input_dir}` command placeholder, including MIMIC-IV. If the option
+is omitted, MEDS-DEV retains the existing behavior and uses a `raw` directory under its temporary build
+directory.
+
 > [!NOTE]
 > Note that you can also specify `demo=True` to build a demo version of this dataset (if supported) for ease
 > of testing the pipeline and your downstream code.
@@ -224,9 +234,10 @@ dataset, containing the following files:
 3. `dataset.yaml`: This file needs to have two keys: `metadata` and `commands`. Under `commands`, you must
     have the keys `build_full` and `build_demo` that, if run in an environment with the requirements installed,
     with the specified placeholder variables (indicated in python syntax, include `temp_dir` for intermediate
-    files and `output_dir` for where you want the final MEDS cohort to live) will produce the desired MEDS
-    cohort. The `metadata` key should contain information about the dataset. See the `MIMIC-IV` dataset for an
-    example of the allowed syntax here. Mandatory keys include `description`, `access_policy`, and the key
+    files, `raw_input_dir` for downloaded source data, and `output_dir` for where you want the final MEDS
+    cohort to live) will produce the desired MEDS cohort. The `metadata` key should contain information about
+    the dataset. See the `MIMIC-IV` dataset for an example of the allowed syntax here. Mandatory keys include
+    `description`, `access_policy`, and the key
     `contacts` with at least one entry. Note that the values for `access_policy` are restricted to the values
     of the `AccessPolicy` `StrEnum` in the `MEDS_DEV.datasets` codebase, namely:
     - `"public_with_approval"`: Data that can be used (in principle) by anyone, but requires approval to access.

--- a/src/MEDS_DEV/configs/_build_dataset.yaml
+++ b/src/MEDS_DEV/configs/_build_dataset.yaml
@@ -5,6 +5,7 @@ dataset: ???
 output_dir: ???
 demo: False
 temp_dir: null # If null, will be determined automatically to a temporary directory.
+raw_input_dir: null # If null, raw source data will be downloaded under temp_dir.
 venv_dir: null
 do_overwrite: False
 
@@ -22,6 +23,6 @@ hydra:
 
       You can specify "dataset" to point to the dataset you want to build, "demo=True" to build the demo
       instead of the full dataset (good for testing), "output_dir" to say where the final, raw MEDS cohort
-      should be stored on disk, and "temp_dir" to overwrite the default temporary directory for storing
-      intermediated files. If you specify "do_overwrite=True", the output directory will be deleted prior to
-      running the command.
+      should be stored on disk, "raw_input_dir" to reuse source data that you already downloaded, and
+      "temp_dir" to overwrite the default temporary directory for storing intermediate files. If you specify
+      "do_overwrite=True", the output directory will be deleted prior to running the command.

--- a/src/MEDS_DEV/datasets/MIMIC-IV/dataset.yaml
+++ b/src/MEDS_DEV/datasets/MIMIC-IV/dataset.yaml
@@ -14,7 +14,7 @@ commands:
   build_full: >-
     MEDS_extract-MIMIC_IV
     root_output_dir="{output_dir}"
-    raw_input_dir="{temp_dir}/raw"
+    raw_input_dir="{raw_input_dir}"
     pre_MEDS_dir="{temp_dir}/pre_MEDS"
     MEDS_output_dir="{output_dir}"
     log_dir="{output_dir}/.pipeline_logs"
@@ -23,7 +23,7 @@ commands:
     MEDS_extract-MIMIC_IV
     root_output_dir="{output_dir}"
     do_demo=True
-    raw_input_dir="{temp_dir}/raw"
+    raw_input_dir="{raw_input_dir}"
     pre_MEDS_dir="{temp_dir}/pre_MEDS"
     MEDS_output_dir="{output_dir}"
     log_dir="{output_dir}/.pipeline_logs"

--- a/src/MEDS_DEV/datasets/__main__.py
+++ b/src/MEDS_DEV/datasets/__main__.py
@@ -11,6 +11,43 @@ from . import CFG_YAML, DATASETS
 logger = logging.getLogger(__name__)
 
 
+def format_build_command(
+    command: str, *, output_dir: str | Path, temp_dir: Path, raw_input_dir: str | Path | None = None
+) -> str:
+    """Format the paths exposed to dataset build commands.
+
+    Args:
+        command: Dataset build command template.
+        output_dir: Destination for the MEDS dataset.
+        temp_dir: Directory used for temporary build files.
+        raw_input_dir: Existing raw dataset directory, or ``None`` to use a directory under ``temp_dir``.
+
+    Returns:
+        The formatted build command.
+
+    Examples:
+        >>> format_build_command(
+        ...     "extract raw={raw_input_dir} tmp={temp_dir} out={output_dir}",
+        ...     output_dir="meds",
+        ...     temp_dir=Path("/tmp/build"),
+        ... )
+        'extract raw=/tmp/build/raw tmp=/tmp/build out=meds'
+        >>> format_build_command(
+        ...     "extract raw={raw_input_dir}",
+        ...     output_dir="meds",
+        ...     temp_dir=Path("/tmp/build"),
+        ...     raw_input_dir="/datasets/mimiciv",
+        ... )
+        'extract raw=/datasets/mimiciv'
+    """
+    raw_input_dir = temp_dir / "raw" if raw_input_dir is None else Path(raw_input_dir).expanduser().resolve()
+    return command.format(
+        output_dir=output_dir,
+        temp_dir=str(temp_dir.resolve()),
+        raw_input_dir=str(raw_input_dir),
+    )
+
+
 @hydra.main(version_base=None, config_path=str(CFG_YAML.parent), config_name=CFG_YAML.stem)
 def main(cfg: DictConfig):
     if cfg.dataset not in DATASETS:
@@ -44,7 +81,12 @@ def main(cfg: DictConfig):
         build_cmd = commands["build_full"]
 
     with temp_env(cfg, requirements) as (build_temp_dir, env):
-        build_cmd = build_cmd.format(output_dir=cfg.output_dir, temp_dir=str(build_temp_dir.resolve()))
+        build_cmd = format_build_command(
+            build_cmd,
+            output_dir=cfg.output_dir,
+            temp_dir=build_temp_dir,
+            raw_input_dir=cfg.get("raw_input_dir"),
+        )
 
         logger.info(f"Considering running build command: {build_cmd}")
         run_in_env(

--- a/tests/test_0_datasets.py
+++ b/tests/test_0_datasets.py
@@ -5,7 +5,28 @@ import pytest
 from meds_testing_helpers.dataset import MEDSDataset
 
 from MEDS_DEV import DATASETS
+from MEDS_DEV.datasets.__main__ import format_build_command
 from tests.utils import NAME_AND_DIR, run_command
+
+
+@pytest.mark.parametrize(
+    ("raw_input_dir", "expected_raw_input_dir"),
+    [(None, "build/raw"), ("downloaded", "downloaded")],
+)
+def test_format_build_command_raw_input_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, raw_input_dir: str | None, expected_raw_input_dir: str
+):
+    monkeypatch.chdir(tmp_path)
+    build_dir = tmp_path / "build"
+
+    command = format_build_command(
+        "extract raw={raw_input_dir} tmp={temp_dir} out={output_dir}",
+        output_dir="meds",
+        temp_dir=build_dir,
+        raw_input_dir=raw_input_dir,
+    )
+
+    assert command == f"extract raw={tmp_path / expected_raw_input_dir} tmp={build_dir} out=meds"
 
 
 def test_non_dataset_breaks():


### PR DESCRIPTION
## Summary

Add a configurable `raw_input_dir` to `meds-dev-dataset` so users can reuse source data that has already been downloaded.

For example:

```bash
meds-dev-dataset \
  dataset=MIMIC-IV \
  raw_input_dir=/data/raw/mimiciv \
  output_dir=/data/meds/mimiciv
```

MIMIC-IV now uses the new `{raw_input_dir}` dataset-command placeholder.

## Motivation

Dataset paths represent two distinct artifacts:

1. The native/raw source data consumed by an ETL.
2. The resulting MEDS cohort.

`output_dir` already controls where the generated MEDS cohort is stored, but dataset recipes currently hard-code raw downloads under `{temp_dir}/raw`. This makes it difficult to reuse large downloads across runs or separate MEDS-DEV output directories.

This is particularly relevant for credentialed datasets such as MIMIC-IV, where downloading the source data can be expensive.

## Behavior

- If `raw_input_dir` is supplied, the dataset ETL receives that path.
- If it is omitted, MEDS-DEV preserves the existing behavior and uses `{temp_dir}/raw`.
- `output_dir` continues to identify the MEDS cohort being produced.
- A successful build continues to create `output_dir/.done`, allowing later invocations with the same `output_dir` to return without rerunning the ETL.
- `do_overwrite=True` continues to apply to `output_dir`; it does not remove a separate `raw_input_dir`.

The raw input and output paths should remain separate:

```text
raw_input_dir --ETL--> output_dir
                         |
                         +-- used as dataset_dir by tasks and models
```

This change does not introduce a new registration mechanism for externally obtained MEDS cohorts. Those can continue to be passed directly as `dataset_dir` to task and model commands.

## Changes

- Add `raw_input_dir` to the dataset-builder Hydra configuration.
- Expose `{raw_input_dir}` when formatting dataset build commands.
- Default it to `{temp_dir}/raw` for backward compatibility.
- Update the MIMIC-IV recipe.
- Document raw-source, MEDS-output, and downstream dataset paths.
- Add regression tests for both default and explicitly supplied paths.

## Testing

- `pytest --doctest-modules -m "not integration" -x`: 55 passed.
- `pre-commit run --all-files`: all hooks passed.
- Comparable fast-suite coverage increased from 81.026% on `dev` to 81.098%; the number of missing statements remained 148.
