### PR TITLE
Support optional `predicates_path` in `meds-dev-model`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,9 @@ models is filtered by compatibility.
 2. `model.yaml` must have `metadata` and `commands` with nested `unsupervised`/`supervised` →
     `train`/`predict` structure
 3. Commands use template variables: `{dataset_dir}`, `{labels_dir}`, `{output_dir}`,
-    `{model_dir}`, `{model_initialization_dir}`, `{split}`, `{demo}`
+    `{model_dir}`, `{model_initialization_dir}`, `{split}`, `{demo}`, and (optionally)
+    `{predicates_path}` for models that need a predicates file (populated from the
+    `predicates_path` argument to `meds-dev-model`)
 4. Predictions must output parquet files compatible with `meds-evaluation`
 
 ### YAML Config Conventions

--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ here, like with a dataset.
 A full description of these commands is coming soon, but for now, note that:
 
 1. Commands can use the template variables `{output_dir}`, `{dataset_dir}`, `{labels_dir}`, and `{demo}`.
+    Models that need a dataset's predicates file (e.g., for featurization) can also use the optional
+    `{predicates_path}` template variable, populated from the `predicates_path` argument to `meds-dev-model`.
 2. Commands should be added in a nested manner for running either over `unsupervised` or `supervised`
     datasets, in either `train` or `predict` modes. See the random predictors example for an example.
 

--- a/src/MEDS_DEV/configs/_run_model.yaml
+++ b/src/MEDS_DEV/configs/_run_model.yaml
@@ -19,6 +19,8 @@ split: null # this is only used for training.
 
 model_initialization_dir: null
 
+predicates_path: null # optional path to a predicates file, for models that need one (e.g., for featurization)
+
 output_dir: ???
 
 hydra:
@@ -60,5 +62,9 @@ hydra:
       appropriate sub-dirs will be created and used for the sequence. In this case, if prior stage completion
       is flagged (e.g., if you use the same dir twice), the stage will not be re-run. The directory structure
       used for these will depend on dataset_name and task_name, so those must be set if this mode is used.
+
+      If a model's commands use the "{predicates_path}" template variable (e.g., to bind dataset-specific
+      predicates for featurization), point "predicates_path" to the appropriate predicates file (such as the
+      dataset's predicates.yaml). It can be left as null for models that do not use it.
 
       If do_overwrite is set to true, the output dir will be cleared before anything is run.

--- a/src/MEDS_DEV/models/__init__.py
+++ b/src/MEDS_DEV/models/__init__.py
@@ -189,6 +189,15 @@ def model_commands(
         >>> list(model_commands(cfg, commands, model_dir))
         [('FT data=data labels=labels output=output', PosixPath('output'))]
 
+    Models that need a dataset's predicates file (e.g., for featurization) can use the optional
+    `predicates_path` template variable, which is populated when `predicates_path` is set in the config:
+        >>> cfg.predicates_path = "predicates.yaml"
+        >>> commands["supervised"]["train"] = (
+        ...     "FT data={dataset_dir} labels={labels_dir} output={output_dir} predicates={predicates_path}"
+        ... )
+        >>> list(model_commands(cfg, commands, model_dir))
+        [('FT data=data labels=labels output=output predicates=predicates.yaml', PosixPath('output'))]
+
     The system errors if a split is set but it is in full mode.
         >>> cfg.split = "tuning"
         >>> cfg.mode = "full"
@@ -212,6 +221,8 @@ def model_commands(
     }
     if cfg.get("model_initialization_dir", None):
         format_kwargs["model_initialization_dir"] = cfg.model_initialization_dir
+    if cfg.get("predicates_path", None):
+        format_kwargs["predicates_path"] = str(cfg.predicates_path)
     if cfg.get("split", None):
         if do_set_split:
             raise ValueError(f"Cannot set split manually when mode is {cfg.mode}.")


### PR DESCRIPTION
## Summary

Adds an optional `predicates_path` argument to `meds-dev-model`, exposed to model commands as the `{predicates_path}` template variable. This lets a `model.yaml` bind a dataset's predicates file when the model needs it — e.g., for concept-level featurization — without affecting any existing model.

## Changes

- `model_commands` (`src/MEDS_DEV/models/__init__.py`): passes `predicates_path` through to command formatting when set, mirroring the existing handling of `model_initialization_dir`. Includes a new doctest.
- `src/MEDS_DEV/configs/_run_model.yaml`: adds `predicates_path: null` and documents it in the `meds-dev-model` help text.
- `README.md` / `CLAUDE.md`: adds `{predicates_path}` to the documented `model.yaml` template variables.

## Usage

```bash
meds-dev-model model=$MODEL_NAME dataset_dir=$DATASET_DIR output_dir=$OUTPUT_DIR \
    predicates_path=/path/to/predicates.yaml ...
```

## Behavior notes

- Backwards compatible: extra format variables are ignored, so models that don't reference `{predicates_path}` are unaffected, and passing the argument to such models is harmless.
- If a model's command uses `{predicates_path}` but the argument isn't provided, formatting fails with a `KeyError` — the same behavior as the other optional template variables.
- This is a pure explicit passthrough: there is no fallback to the registered dataset's `predicates.yaml` via `dataset_name` (unlike `meds-dev-task`'s `dataset_predicates_path` handling). That could be a follow-up if automatic binding for registered datasets is desirable.

## Testing

- Module doctests pass, including a new one covering the passthrough; a coverage run confirms the new lines are exercised.
- Fast tier (`pytest --doctest-modules -m "not integration"`): 72 passed.
- `pre-commit` hooks pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)