### PR TITLE
Demonstrate model predicates path with random predictor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,9 @@ models is filtered by compatibility.
 2. `model.yaml` must have `metadata` and `commands` with nested `unsupervised`/`supervised` →
     `train`/`predict` structure
 3. Commands use template variables: `{dataset_dir}`, `{labels_dir}`, `{output_dir}`,
-    `{model_dir}`, `{model_initialization_dir}`, `{split}`, `{demo}`
+    `{model_dir}`, `{model_initialization_dir}`, `{split}`, `{demo}`, and (optionally)
+    `{predicates_path}` for models that need a predicates file (populated from the
+    `predicates_path` argument to `meds-dev-model`)
 4. Predictions must output parquet files compatible with `meds-evaluation`
 
 ### YAML Config Conventions

--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ here, like with a dataset.
 A full description of these commands is coming soon, but for now, note that:
 
 1. Commands can use the template variables `{output_dir}`, `{dataset_dir}`, `{labels_dir}`, and `{demo}`.
+    Models that need a dataset's predicates file (e.g., for featurization) can also use the optional
+    `{predicates_path}` template variable, populated from the `predicates_path` argument to `meds-dev-model`.
 2. Commands should be added in a nested manner for running either over `unsupervised` or `supervised`
     datasets, in either `train` or `predict` modes. See the random predictors example for an example.
 

--- a/src/MEDS_DEV/configs/_run_model.yaml
+++ b/src/MEDS_DEV/configs/_run_model.yaml
@@ -19,6 +19,8 @@ split: null # this is only used for training.
 
 model_initialization_dir: null
 
+predicates_path: null # optional path to a predicates file, for models that need one (e.g., for featurization)
+
 output_dir: ???
 
 hydra:
@@ -60,5 +62,9 @@ hydra:
       appropriate sub-dirs will be created and used for the sequence. In this case, if prior stage completion
       is flagged (e.g., if you use the same dir twice), the stage will not be re-run. The directory structure
       used for these will depend on dataset_name and task_name, so those must be set if this mode is used.
+
+      If a model's commands use the "{predicates_path}" template variable (e.g., to bind dataset-specific
+      predicates for featurization), point "predicates_path" to the appropriate predicates file (such as the
+      dataset's predicates.yaml). It can be left as null for models that do not use it.
 
       If do_overwrite is set to true, the output dir will be cleared before anything is run.

--- a/src/MEDS_DEV/models/__init__.py
+++ b/src/MEDS_DEV/models/__init__.py
@@ -189,6 +189,15 @@ def model_commands(
         >>> list(model_commands(cfg, commands, model_dir))
         [('FT data=data labels=labels output=output', PosixPath('output'))]
 
+    Models that need a dataset's predicates file (e.g., for featurization) can use the optional
+    `predicates_path` template variable, which is populated when `predicates_path` is set in the config:
+        >>> cfg.predicates_path = "predicates.yaml"
+        >>> commands["supervised"]["train"] = (
+        ...     "FT data={dataset_dir} labels={labels_dir} output={output_dir} predicates={predicates_path}"
+        ... )
+        >>> list(model_commands(cfg, commands, model_dir))
+        [('FT data=data labels=labels output=output predicates=predicates.yaml', PosixPath('output'))]
+
     The system errors if a split is set but it is in full mode.
         >>> cfg.split = "tuning"
         >>> cfg.mode = "full"
@@ -212,6 +221,8 @@ def model_commands(
     }
     if cfg.get("model_initialization_dir", None):
         format_kwargs["model_initialization_dir"] = cfg.model_initialization_dir
+    if cfg.get("predicates_path", None):
+        format_kwargs["predicates_path"] = str(cfg.predicates_path)
     if cfg.get("split", None):
         if do_set_split:
             raise ValueError(f"Cannot set split manually when mode is {cfg.mode}.")

--- a/src/MEDS_DEV/models/__init__.py
+++ b/src/MEDS_DEV/models/__init__.py
@@ -198,6 +198,14 @@ def model_commands(
         >>> list(model_commands(cfg, commands, model_dir))
         [('FT data=data labels=labels output=output predicates=predicates.yaml', PosixPath('output'))]
 
+    If a model command needs the variable but the caller does not provide it, command formatting fails
+    immediately instead of running the model without its required predicates:
+        >>> cfg.predicates_path = None
+        >>> list(model_commands(cfg, commands, model_dir))
+        Traceback (most recent call last):
+            ...
+        KeyError: 'predicates_path'
+
     The system errors if a split is set but it is in full mode.
         >>> cfg.split = "tuning"
         >>> cfg.mode = "full"

--- a/src/MEDS_DEV/models/random_predictor/README.md
+++ b/src/MEDS_DEV/models/random_predictor/README.md
@@ -3,3 +3,7 @@
 This is a random, dummy predictor for use primarily in testing. It literally just spits out random
 predictions. The predictions are not calibrated to the base rate of the task, they are truly just random with
 a chance value of 0.5.
+
+Its command also demonstrates how a model can receive the current dataset's predicate definitions through
+the `{predicates_path}` template variable. The predictor does not use those definitions to generate its
+baseline, but verifies that the configured file exists.

--- a/src/MEDS_DEV/models/random_predictor/_config.yaml
+++ b/src/MEDS_DEV/models/random_predictor/_config.yaml
@@ -4,6 +4,7 @@ defaults:
 
 dataset_dir: ???
 labels_dir: ???
+predicates_path: null
 output_dir: ???
 predictions_fp: ${output_dir}/predictions.parquet
 split: "held_out"

--- a/src/MEDS_DEV/models/random_predictor/generate_random_predictions.py
+++ b/src/MEDS_DEV/models/random_predictor/generate_random_predictions.py
@@ -53,6 +53,19 @@ def main(cfg: DictConfig) -> None:
         ...
     ValueError: Split train does not match ...
 
+    >>> cfg = DictConfig({
+    ...     "split": "held_out",
+    ...     "dataset_dir": "data/dataset",
+    ...     "labels_dir": "data/labels",
+    ...     "predicates_path": "data/missing_predicates.yaml",
+    ...     "predictions_fp": "data/predictions.parquet",
+    ...     "seed": 42,
+    ... })
+    >>> main(cfg)
+    Traceback (most recent call last):
+        ...
+    FileNotFoundError: Could not find predicates file data/missing_predicates.yaml.
+
     >>> import tempfile, os
     >>> with tempfile.TemporaryDirectory() as tmp_dir:
     ...     cfg = DictConfig({

--- a/src/MEDS_DEV/models/random_predictor/generate_random_predictions.py
+++ b/src/MEDS_DEV/models/random_predictor/generate_random_predictions.py
@@ -26,6 +26,7 @@ def main(cfg: DictConfig) -> None:
         cfg: The configuration object, controlled through Hydra command line arguments. Takes:
           - dataset_dir: The directory containing the dataset.
           - labels_dir: The directory containing the labels.
+          - predicates_path: The dataset predicates file passed through by MEDS-DEV.
           - predictions_fp: The file path to write the predictions to.
           - seed: The random seed to use for generating predictions.
           - split: The split to generate predictions for. Must be the held-out split.
@@ -150,6 +151,11 @@ def main(cfg: DictConfig) -> None:
     predictions_fp = Path(cfg.predictions_fp)
     predictions_fp.parent.mkdir(parents=True, exist_ok=True)
     seed = cfg.seed
+
+    if cfg.get("predicates_path") is not None:
+        predicates_path = Path(cfg.predicates_path)
+        if not predicates_path.is_file():
+            raise FileNotFoundError(f"Could not find predicates file {predicates_path}.")
 
     if cfg.split != meds.held_out_split:
         raise ValueError(

--- a/src/MEDS_DEV/models/random_predictor/model.yaml
+++ b/src/MEDS_DEV/models/random_predictor/model.yaml
@@ -13,4 +13,4 @@ commands:
     train: null
     predict: >-
       python -m MEDS_DEV.models.random_predictor.generate_random_predictions labels_dir={labels_dir}
-      output_dir={output_dir} split={split} dataset_dir={dataset_dir}
+      output_dir={output_dir} split={split} dataset_dir={dataset_dir} predicates_path={predicates_path}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -606,6 +606,7 @@ def supervised_model(
         "dataset_dir": str(dataset_dir.resolve()),
         "labels_dir": str(task_labels_dir.resolve()),
         "dataset_name": dataset_name,
+        "predicates_path": str(DATASETS[dataset_name]["predicates"]),
         "task_name": task_name,
         "demo": True,
     }


### PR DESCRIPTION
## Dependency

This PR is stacked on and depends on #325. Please review and merge #325 first. Until #325 merges into `dev`, this PR's diff also includes that prerequisite commit; afterward, GitHub will show only the demonstration changes here.

## What changed

- wires the dataset `predicates_path` through the model integration fixture
- updates `random_predictor` to demonstrate `{predicates_path}` command-template substitution
- verifies that the supplied predicates file exists
- documents the random predictor example
- demonstrates the relevant omitted-value behavior: when a model command requires `{predicates_path}` but the caller does not supply it, command formatting fails immediately with `KeyError: 'predicates_path'`

## Why

PR #325 adds optional `predicates_path` support to `meds-dev-model`. This follow-up provides a concrete, exercised example of the feature and makes the required-but-omitted behavior explicit.

## Validation

- `uv run pre-commit run --all-files`
- focused doctests and registry tests: 15 passed
- `uv run pytest -m 'not integration'`: 42 passed, 126 deselected